### PR TITLE
[ENGINE] Fix build failures on newer GCC versions

### DIFF
--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -22,6 +22,7 @@
 #include <vp/vp.hpp>
 #include <vp/signal.hpp>
 #include <vp/register.hpp>
+#include <algorithm>
 
 vp::BlockObject::BlockObject(Block &parent)
 {

--- a/engine/src/time/block_time.cpp
+++ b/engine/src/time/block_time.cpp
@@ -23,7 +23,7 @@
 #include <vp/signal.hpp>
 #include <vp/time/block_time.hpp>
 #include <vp/time/time_event.hpp>
-
+#include <algorithm>
 
 vp::BlockTime::BlockTime(vp::Block *parent, vp::Block &top, vp::TimeEngine *engine) : top(top), time_engine(engine)
 {


### PR DESCRIPTION
Newer GCC versions (13 onwards) have changed the transitive includes of standard library headers causing code that previously worked "accidently" to no longer compile. In this specific case I was getting errors compiling files due to not finding `std::remove`. This PR adds `#include <algorithm>` where required to fix the issue.