### PR TITLE
[CMAKE] Find gapy instead of using `PATH`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,18 @@ if(DEFINED GVSOC_TARGETS)
 
         message(STATUS "Generating GVSOC config to ${TARGET_CONFIG} with command: ")
 
+        # Prefer active venvs.
+        set(Python_FIND_VIRTUALENV "FIRST")
+        find_package(Python COMPONENTS Interpreter REQUIRED)
+
+        find_program(GAPY_SCRIPT_PATH gapy
+                # Hint to use in case we are in the monorepo layout.
+                HINTS ${CMAKE_CURRENT_LIST_DIR}/../gapy/bin
+                REQUIRED
+                DOC "Path to the gapy script to use for generating components")
+
         # Gapy is used to extract the list of components out of the specified target
-        set(GAPY_CMD gapy --target=${target} ${GAPY_TARGETS_DIR_OPT}
+        set(GAPY_CMD ${Python_EXECUTABLE} ${GAPY_SCRIPT_PATH} --target=${target} ${GAPY_TARGETS_DIR_OPT}
             --platform=gvsoc
             --builddir=${CMAKE_CURRENT_BINARY_DIR}
             --installdir=${CMAKE_INSTALL_PREFIX}/models


### PR DESCRIPTION
The cmake script previously relied on `gapy` needing to be in the PATH. This makes the cmake script less self-contained and adds a magic ceremonial step required to configure the cmake build.

This PR therefore uses cmake's `find_program` to find the `gapy` script instead. This has the following advantages:
* We can specify hints where cmake should try and find `gapy`. This way we can add the path from the monorepo layout as a convenient default
* If not found through hints, `find_program` will look in `PATH` preserving previous behavior
* The `gapy` executable can also be overwritten on the command line using `-DGAPY_SCRIPT_PATH=...`
* If not found, a nicer error message is omitted by cmake

Additionally, the `gapy` script is now executed using the python interpreter CMake was configured with, not the one that is currently active. This should better ensure that it is always using a venv with the requirements installed if desired.