### PR TITLE
fix: exposed offset_shift value to the ns16550 UART class

### DIFF
--- a/models/devices/uart/ns16550.cpp
+++ b/models/devices/uart/ns16550.cpp
@@ -490,6 +490,8 @@ Ns16550::Ns16550(vp::ComponentConf &config)
 
     reg_io_width = 1;
 
+    this->reg_shift = this->get_js_config()->get_child_int("offset_shift");
+
     this->input_itf.set_req_meth(&Ns16550::req);
     new_slave_port("input", &this->input_itf);
 

--- a/models/devices/uart/ns16550.py
+++ b/models/devices/uart/ns16550.py
@@ -18,11 +18,13 @@ import gvsoc.systree
 
 class Ns16550(gvsoc.systree.Component):
 
-    def __init__(self, parent, name):
+    def __init__(self, parent, name, offset_shift=0):
 
         super(Ns16550, self).__init__(parent, name)
 
         self.set_component('devices.uart.ns16550')
+        
+        self.add_property('offset_shift', offset_shift)
 
     def i_INPUT(self) -> gvsoc.systree.SlaveItf:
         return gvsoc.systree.SlaveItf(self, 'input', signature='io')


### PR DESCRIPTION
## Description

The `reg_shift` variable inside `ns16550.cpp` (UART model) was not initialized, implicitly defaulting to zero. This caused incorrect behavior in register address decoding when the UART was expected to operate with shifted addresses.

This patch fixes the issue by initializing `reg_shift` from the component configuration property `"offset_shift"`.
