### PR TITLE
[ns16550] Fix segfault when irq port is not connected.

### DIFF
--- a/models/devices/uart/ns16550.cpp
+++ b/models/devices/uart/ns16550.cpp
@@ -222,12 +222,18 @@ void Ns16550::update_interrupt(void)
     if (!interrupts)
     {
         iir = UART_IIR_NO_INT;
-        this->irq_itf.sync(false);
+        if (this->irq_itf.is_bound())
+        {
+            this->irq_itf.sync(false);
+        }
     }
     else
     {
         iir = interrupts;
-        this->irq_itf.sync(true);
+        if (this->irq_itf.is_bound())
+        {
+            this->irq_itf.sync(true);
+        }
     }
 
     /*


### PR DESCRIPTION
Check was missing for the ```irq_itf``` in the ```update_interrupt()``` call within ```ns16550.cpp```. If the ```irq``` port of ```ns16550``` is unused and left disconnected, a segmentation fault will occur at runtime. This patch adds ```irq_itf.is_bound()``` check before calling ```irq_itf.sync()``` to prevent the crash.