### PR TITLE
[INTERLEAVER] Fix req latency calculation.

### DIFF
--- a/models/interco/interleaver_impl.cpp
+++ b/models/interco/interleaver_impl.cpp
@@ -134,7 +134,6 @@ vp::IoReqStatus interleaver::req(vp::Block *__this, vp::IoReq *req)
     req->set_addr(new_offset);
     req->set_size(loop_size);
     req->set_data(data);
-    req->set_latency(0);
 
     vp::IoReqStatus err = _this->out[output_id]->req_forward(req);
     if (err != vp::IO_REQ_OK)


### PR DESCRIPTION
Fix the latency calculation so that the latency of the targets can be added together with the latency before reaching Interleaver.