### PR TITLE
iss: added support for outstanding requests

### DIFF
--- a/models/cpu/iss/include/cores/snitch_fast/fpu_lsu.hpp
+++ b/models/cpu/iss/include/cores/snitch_fast/fpu_lsu.hpp
@@ -30,8 +30,8 @@ public:
 
     FpuLsu(IssWrapper &top, Iss &iss);
 
-    int data_req(iss_addr_t addr, uint8_t *data, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency);
-    int data_req_aligned(iss_addr_t addr, uint8_t *data_ptr, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency);
+    int data_req(iss_addr_t addr, uint8_t *data, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency, int &req_id);
+    int data_req_aligned(iss_addr_t addr, uint8_t *data_ptr, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency, int &req_id);
     int data_misaligned_req(iss_addr_t addr, uint8_t *data_ptr, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency);
 
     template<typename T>
@@ -51,9 +51,15 @@ public:
     vp::Trace trace;
 
     vp::IoReq io_req;
-    void (*stall_callback)(FpuLsu *lsu);
+#ifdef CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING
+    void (*stall_callback[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING])(FpuLsu *lsu, vp::IoReq *req);
+    int stall_reg[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING];
+    int stall_size[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING];
+#else
+    void (*stall_callback)(FpuLsu *lsu, vp::IoReq *req);
     int stall_reg;
     int stall_size;
+#endif
     int misaligned_size;
     uint8_t *misaligned_data;
     uint8_t *misaligned_memcheck_data;
@@ -61,8 +67,8 @@ public:
     bool misaligned_is_write;
 
 private:
-    static void load_float_resume(FpuLsu *lsu);
-    static void store_resume(FpuLsu *lsu);
+    static void load_float_resume(FpuLsu *lsu, vp::IoReq *req);
+    static void store_resume(FpuLsu *lsu, vp::IoReq *req);
 
     int64_t pending_latency;
 };

--- a/models/cpu/iss/include/isa/pulp_nn.hpp
+++ b/models/cpu/iss/include/isa/pulp_nn.hpp
@@ -248,16 +248,16 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
 
 /* Sign 0 if unsigned, 1 if signed */
 #define PV_OP_RRRU3_EXEC_NN(insn_name, lib_name, signOpA)                                                         \
-    static inline void pv_##insn_name##_h_resume(Lsu *lsu)                                                        \
+    static inline void pv_##insn_name##_h_resume(Lsu *lsu, vp::IoReq *req)                                                        \
     {                                                                                                             \
     }                                                                                                             \
-    static inline void pv_##insn_name##_b_resume(Lsu *lsu)                                                        \
+    static inline void pv_##insn_name##_b_resume(Lsu *lsu, vp::IoReq *req)                                                        \
     {                                                                                                             \
     }                                                                                                             \
-    static inline void pv_##insn_name##_n_resume(Lsu *lsu)                                                        \
+    static inline void pv_##insn_name##_n_resume(Lsu *lsu, vp::IoReq *req)                                                        \
     {                                                                                                             \
     }                                                                                                             \
-    static inline void pv_##insn_name##_c_resume(Lsu *lsu)                                                        \
+    static inline void pv_##insn_name##_c_resume(Lsu *lsu, vp::IoReq *req)                                                        \
     {                                                                                                             \
     }                                                                                                             \
     static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                                 \
@@ -282,7 +282,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", ac_addr, SPR_GET(ac_addr)); \
             }                                                                                                     \
@@ -299,7 +300,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", wt_addr, SPR_GET(wt_addr)); \
             }                                                                                                     \
@@ -340,7 +342,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", ac_addr, SPR_GET(ac_addr)); \
             }                                                                                                     \
@@ -357,7 +360,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", wt_addr, SPR_GET(wt_addr)); \
             }                                                                                                     \
@@ -398,7 +402,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", ac_addr, SPR_GET(ac_addr)); \
             }                                                                                                     \
@@ -415,7 +420,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", wt_addr, SPR_GET(wt_addr)); \
             }                                                                                                     \
@@ -456,7 +462,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[ac_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", ac_addr, SPR_GET(ac_addr)); \
             }                                                                                                     \
@@ -473,7 +480,8 @@ PV_OP_RRU_EXEC_NN_2(sdotup, SDOTUP)
         {                                                                                                         \
             iss_reg_t addr = REG_GET(1);                                                                          \
             int64_t latency;                                                                                      \
-            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency))            \
+            int req_id;                                                                                           \
+            if (!iss->lsu.data_req(addr, (uint8_t *)&iss->pulp_nn.spr_ml[wt_addr], NULL, 4, false, latency, req_id))            \
             {                                                                                                     \
                 iss->lsu.trace.msg("Loaded new value (spr_loc: 0x%x, value: 0x%x)\n", wt_addr, SPR_GET(wt_addr)); \
             }                                                                                                     \
@@ -498,7 +506,7 @@ PV_OP_RRRU3_EXEC_NN(mlsdotusp, SDOTUSP, 0)
 PV_OP_RRRU3_EXEC_NN(mlsdotsup, SDOTUSP, 1)
 PV_OP_RRRU3_EXEC_NN(mlsdotsp, SDOTSP, 1)
 
-static inline void qnt_step_resume(Lsu *lsu)
+static inline void qnt_step_resume(Lsu *lsu, vp::IoReq *req)
 {
 }
 
@@ -518,7 +526,8 @@ static inline iss_reg_t qnt_step(Iss *iss, iss_insn_t *insn, iss_reg_t pc, iss_r
         // printf("here1\n" );
         // iss->lsu.data_req(iss->pulp_nn.addr_reg, data, 2, false);
         int64_t latency;
-        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency))
+        int req_id;
+        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency, req_id))
         {
             // printf("qnt_add: %X\n",iss->pulp_nn.addr_reg );
             // printf("data: %d\n", *((int16_t*)data) );
@@ -553,7 +562,8 @@ static inline iss_reg_t qnt_step(Iss *iss, iss_insn_t *insn, iss_reg_t pc, iss_r
     {
         // printf("qnt2,here1\n");
         int64_t latency;
-        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency))
+        int req_id;
+        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency, req_id))
         {
             // printf("qnt_add: %X\n",iss->pulp_nn.addr_reg );
             // printf("data: %d\n", *((int16_t*)data) );
@@ -587,7 +597,8 @@ static inline iss_reg_t qnt_step(Iss *iss, iss_insn_t *insn, iss_reg_t pc, iss_r
     {
         // printf("qnt3,here1\n");
         int64_t latency;
-        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency))
+        int req_id;
+        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency, req_id))
         // iss->lsu.data_req(iss->pulp_nn.addr_reg, data, 2, false);
         {
             // printf("qnt_add: %X\n",iss->pulp_nn.addr_reg );
@@ -622,7 +633,8 @@ static inline iss_reg_t qnt_step(Iss *iss, iss_insn_t *insn, iss_reg_t pc, iss_r
     {
         // printf("qnt4,here1\n");
         int64_t latency;
-        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency))
+        int req_id;
+        if (!iss->lsu.data_req(iss->pulp_nn.addr_reg, data, NULL, 2, false, latency, req_id))
         // iss->lsu.data_req(iss->pulp_nn.addr_reg, data, 2, false);
         {
             // printf("qnt_add: %X\n",iss->pulp_nn.addr_reg );

--- a/models/cpu/iss/include/isa/pulp_v2.hpp
+++ b/models/cpu/iss/include/isa/pulp_v2.hpp
@@ -36,7 +36,11 @@
 
 static inline iss_reg_t LB_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0));
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -58,7 +62,11 @@ static inline iss_reg_t LB_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t LH_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0));
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -80,7 +88,11 @@ static inline iss_reg_t LH_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t LW_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<int32_t>(insn, REG_GET(0) + REG_GET(1), 4, REG_OUT(0));
+    if (iss->lsu.load<int32_t>(insn, REG_GET(0) + REG_GET(1), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -102,7 +114,11 @@ static inline iss_reg_t LW_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t LBU_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0));
+    if (iss->lsu.load<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -124,7 +140,11 @@ static inline iss_reg_t LBU_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t LHU_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0));
+    if (iss->lsu.load<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -146,7 +166,11 @@ static inline iss_reg_t LHU_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t LB_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int8_t>(insn, REG_GET(0), 1, REG_OUT(0));
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -169,7 +193,11 @@ static inline iss_reg_t LB_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
 
 static inline iss_reg_t LH_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int16_t>(insn, REG_GET(0), 2, REG_OUT(0));
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -192,7 +220,11 @@ static inline iss_reg_t LH_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
 
 static inline iss_reg_t LW_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int32_t>(insn, REG_GET(0), 4, REG_OUT(0));
+    if (iss->lsu.load_signed<int32_t>(insn, REG_GET(0), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -215,7 +247,11 @@ static inline iss_reg_t LW_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
 
 static inline iss_reg_t LBU_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<int8_t>(insn, REG_GET(0), 1, REG_OUT(0));
+    if (iss->lsu.load<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -239,7 +275,11 @@ static inline iss_reg_t LBU_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t p
 
 static inline iss_reg_t LHU_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<int16_t>(insn, REG_GET(0), 2, REG_OUT(0));
+    if (iss->lsu.load<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -263,7 +303,11 @@ static inline iss_reg_t LHU_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t p
 
 static inline iss_reg_t SB_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint8_t>(insn, REG_GET(0), 1, REG_IN(1));
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -287,7 +331,11 @@ static inline iss_reg_t SB_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
 
 static inline iss_reg_t SH_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint16_t>(insn, REG_GET(0), 2, REG_IN(1));
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -311,7 +359,11 @@ static inline iss_reg_t SH_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
 
 static inline iss_reg_t SW_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint32_t>(insn, REG_GET(0), 4, REG_IN(1));
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
     return iss_insn_next(iss, insn, pc);
 }
@@ -336,7 +388,11 @@ static inline iss_reg_t SW_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc
 static inline iss_reg_t LB_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(1);
-    iss->lsu.load_signed<int8_t>(insn, REG_GET(0), 1, REG_OUT(0));
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -362,7 +418,11 @@ static inline iss_reg_t LB_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
 static inline iss_reg_t LH_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(1);
-    iss->lsu.load_signed<int16_t>(insn, REG_GET(0), 2, REG_OUT(0));
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -388,7 +448,11 @@ static inline iss_reg_t LH_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
 static inline iss_reg_t LW_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(1);
-    iss->lsu.load_signed<int32_t>(insn, REG_GET(0), 4, REG_OUT(0));
+    if (iss->lsu.load_signed<int32_t>(insn, REG_GET(0), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -414,7 +478,11 @@ static inline iss_reg_t LW_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
 static inline iss_reg_t LBU_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(1);
-    iss->lsu.load<uint8_t>(insn, REG_GET(0), 1, REG_OUT(0));
+    if (iss->lsu.load<uint8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -441,7 +509,11 @@ static inline iss_reg_t LBU_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_
 static inline iss_reg_t LHU_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(1);
-    iss->lsu.load<uint16_t>(insn, REG_GET(0), 2, REG_OUT(0));
+    if (iss->lsu.load<uint16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -468,7 +540,11 @@ static inline iss_reg_t LHU_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_
 static inline iss_reg_t SB_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(2);
-    iss->lsu.store<uint8_t>(insn, REG_GET(0), 1, REG_IN(1));
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -495,7 +571,11 @@ static inline iss_reg_t SB_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
 static inline iss_reg_t SH_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(2);
-    iss->lsu.store<uint16_t>(insn, REG_GET(0), 2, REG_IN(1));
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -522,7 +602,11 @@ static inline iss_reg_t SH_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
 static inline iss_reg_t SW_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
     iss_reg_t new_val = REG_GET(0) + REG_GET(2);
-    iss->lsu.store<uint32_t>(insn, REG_GET(0), 4, REG_IN(1));
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     IN_REG_SET(0, new_val);
     return iss_insn_next(iss, insn, pc);
 }
@@ -845,7 +929,11 @@ static inline iss_reg_t p_abs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t SB_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint8_t>(insn, REG_GET(0) + REG_GET(2), 1, REG_IN(1));
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0) + REG_GET(2), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -867,7 +955,11 @@ static inline iss_reg_t SB_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t SH_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint16_t>(insn, REG_GET(0) + REG_GET(2), 2, REG_IN(1));
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0) + REG_GET(2), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -889,7 +981,11 @@ static inline iss_reg_t SH_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t SW_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint32_t>(insn, REG_GET(0) + REG_GET(2), 4, REG_IN(1));
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0) + REG_GET(2), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 

--- a/models/cpu/iss/include/isa/rnnext.hpp
+++ b/models/cpu/iss/include/isa/rnnext.hpp
@@ -22,7 +22,7 @@
 #ifndef __CPU_ISS_RNNEXT_HPP
 #define __CPU_ISS_RNNEXT_HPP
 
-static inline void pl_sdotsp_h_0_load_resume(Lsu *lsu)
+static inline void pl_sdotsp_h_0_load_resume(Lsu *lsu, vp::IoReq *req)
 {
     iss_insn_t *insn = lsu->iss.rnnext.sdot_insn;
     lsu->iss.csr.trace.msg("Loaded new sdot_prefetch_0 value (value: 0x%x)\n", lsu->iss.rnnext.sdot_prefetch_0);
@@ -36,7 +36,8 @@ static inline iss_reg_t pl_sdotsp_h_0_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
     REG_SET(0, LIB_CALL3(lib_VEC_SDOTSP_16, REG_GET(2), iss->rnnext.sdot_prefetch_0, REG_GET(1)));
 
     int64_t latency;
-    if (!iss->lsu.data_req(addr, (uint8_t *)&iss->rnnext.sdot_prefetch_0, NULL, 4, false, latency))
+    int req_id;
+    if (!iss->lsu.data_req(addr, (uint8_t *)&iss->rnnext.sdot_prefetch_0, NULL, 4, false, latency, req_id))
     {
         iss->csr.trace.msg("Loaded new sdot_prefetch_0 value (value: 0x%x)\n", iss->rnnext.sdot_prefetch_0);
     }
@@ -50,7 +51,7 @@ static inline iss_reg_t pl_sdotsp_h_0_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
     return iss_insn_next(iss, insn, pc);
 }
 
-static inline void pl_sdotsp_h_1_load_resume(Lsu *lsu)
+static inline void pl_sdotsp_h_1_load_resume(Lsu *lsu, vp::IoReq *req)
 {
     iss_insn_t *insn = lsu->iss.rnnext.sdot_insn;
     lsu->iss.csr.trace.msg("Loaded new sdot_prefetch_1 value (value: 0x%x)\n", lsu->iss.rnnext.sdot_prefetch_1);
@@ -64,7 +65,8 @@ static inline iss_reg_t pl_sdotsp_h_1_exec(Iss *iss, iss_insn_t *insn, iss_reg_t
     REG_SET(0, LIB_CALL3(lib_VEC_SDOTSP_16, REG_GET(2), iss->rnnext.sdot_prefetch_1, REG_GET(1)));
 
     int64_t latency;
-    if (!iss->lsu.data_req(addr, (uint8_t *)&iss->rnnext.sdot_prefetch_1, NULL, 4, false, latency))
+    int req_id;
+    if (!iss->lsu.data_req(addr, (uint8_t *)&iss->rnnext.sdot_prefetch_1, NULL, 4, false, latency, req_id))
     {
         iss->csr.trace.msg("Loaded new sdot_prefetch_1 value (value: 0x%x)\n", iss->rnnext.sdot_prefetch_1);
     }

--- a/models/cpu/iss/include/isa/rv32i.hpp
+++ b/models/cpu/iss/include/isa/rv32i.hpp
@@ -300,7 +300,11 @@ static inline iss_reg_t bgeu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t lb_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int8_t>(insn, REG_GET(0) + SIM_GET(0), 1, REG_OUT(0));
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0) + SIM_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -320,7 +324,11 @@ static inline iss_reg_t lb_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t lh_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int16_t>(insn, REG_GET(0) + SIM_GET(0), 2, REG_OUT(0));
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0) + SIM_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -340,7 +348,11 @@ static inline iss_reg_t lh_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t lw_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int32_t>(insn, REG_GET(0) + SIM_GET(0), 4, REG_OUT(0));
+    if (iss->lsu.load_signed<int32_t>(insn, REG_GET(0) + SIM_GET(0), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -360,7 +372,11 @@ static inline iss_reg_t lw_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t lbu_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<uint8_t>(insn, REG_GET(0) + SIM_GET(0), 1, REG_OUT(0));
+    if (iss->lsu.load<uint8_t>(insn, REG_GET(0) + SIM_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -376,7 +392,11 @@ static inline iss_reg_t lbu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t lhu_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<uint16_t>(insn, REG_GET(0) + SIM_GET(0), 2, REG_OUT(0));
+    if (iss->lsu.load<uint16_t>(insn, REG_GET(0) + SIM_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -392,7 +412,11 @@ static inline iss_reg_t lhu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t sb_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint8_t>(insn, REG_GET(0) + SIM_GET(0), 1, REG_IN(1));
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0) + SIM_GET(0), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -412,7 +436,11 @@ static inline iss_reg_t sb_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t sh_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint16_t>(insn, REG_GET(0) + SIM_GET(0), 2, REG_IN(1));
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0) + SIM_GET(0), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -432,7 +460,11 @@ static inline iss_reg_t sh_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t sw_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint32_t>(insn, REG_GET(0) + SIM_GET(0), 4, REG_IN(1));
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0) + SIM_GET(0), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 

--- a/models/cpu/iss/include/isa/rv64i.hpp
+++ b/models/cpu/iss/include/isa/rv64i.hpp
@@ -27,7 +27,11 @@
 
 static inline iss_reg_t lwu_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load<uint32_t>(insn, REG_GET(0) + SIM_GET(0), 4, REG_OUT(0));
+    if (iss->lsu.load<uint32_t>(insn, REG_GET(0) + SIM_GET(0), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -43,7 +47,11 @@ static inline iss_reg_t lwu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t ld_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.load_signed<int64_t>(insn, REG_GET(0) + SIM_GET(0), 8, REG_OUT(0));
+    if (iss->lsu.load_signed<int64_t>(insn, REG_GET(0) + SIM_GET(0), 8, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 
@@ -59,7 +67,11 @@ static inline iss_reg_t ld_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 
 static inline iss_reg_t sd_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
-    iss->lsu.store<uint64_t>(insn, REG_GET(0) + SIM_GET(0), 8, REG_IN(1));
+    if (iss->lsu.store<uint64_t>(insn, REG_GET(0) + SIM_GET(0), 8, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
     return iss_insn_next(iss, insn, pc);
 }
 

--- a/models/cpu/iss/include/lsu.hpp
+++ b/models/cpu/iss/include/lsu.hpp
@@ -41,8 +41,8 @@ public:
     void start();
     void reset(bool active);
 
-    int data_req(iss_addr_t addr, uint8_t *data, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency);
-    int data_req_aligned(iss_addr_t addr, uint8_t *data_ptr, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency);
+    int data_req(iss_addr_t addr, uint8_t *data, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency, int &req_id);
+    int data_req_aligned(iss_addr_t addr, uint8_t *data_ptr, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency, int &req_id);
     int data_misaligned_req(iss_addr_t addr, uint8_t *data_ptr, uint8_t *memcheck_data, int size, bool is_write, int64_t &latency);
 
     static void exec_misaligned(vp::Block *__this, vp::ClockEvent *event);
@@ -86,6 +86,14 @@ public:
 
     inline void stack_access_check(int reg, iss_addr_t addr);
 
+    // Allocate a request. This can returns NULL if the core can not send more requests (last one
+    // was denied or all requests are already allocated). In this case the core should stall.
+    inline vp::IoReq *get_req();
+    // Free a request so that it can be used for another access.
+    // The cyclestamp indicates when the request becomes free. This allows easily freeing requests
+    // during synchronous responses.
+    inline void free_req(vp::IoReq *req, int64_t cyclestamp);
+
     Iss &iss;
 
     vp::Trace trace;
@@ -94,7 +102,18 @@ public:
     // lsu
     vp::IoMaster data;
     vp::WireMaster<void *> meminfo;
+#ifdef CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING
+    // First availabel request. They are sorted out by increasing cyclestamp. The cyclestamp
+    // indicates when the request becomes available. First request is the next one to be free,
+    // its cyclestamp must be compared against engine cycle to know if it is free in the current
+    // cycle.
+    vp::IoReq *io_req_first;
+    // List of requests which can be sent at the same time.
+    vp::IoReq io_req[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING];
+#else
     vp::IoReq io_req;
+#endif
+    vp::IoReq debug_req;
     int misaligned_size;
     uint8_t *misaligned_data;
     uint8_t *misaligned_memcheck_data;
@@ -104,20 +123,31 @@ public:
 
     // A callback can be set here, so that it is called when the response of a pending
     // request is received.
-    void (*stall_callback)(Lsu *lsu);
+#ifdef CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING
+    // When using multiple outstanding request, each on-going request can have its callback
+    // used when the response arrives.
+    void (*stall_callback[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING])(Lsu *lsu, vp::IoReq *req);
+    int stall_reg[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING];
+    int stall_size[CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING];
+#else
+    void (*stall_callback)(Lsu *lsu, vp::IoReq *req);
     int stall_reg;
     int stall_size;
+#endif
     uint8_t *mem_array;
     iss_addr_t memory_start;
     iss_addr_t memory_end;
 
 private:
-    static void store_resume(void *_this);
-    static void store_resume(Lsu *lsu);
-    static void load_resume(Lsu *lsu);
-    static void elw_resume(Lsu *lsu);
-    static void load_signed_resume(Lsu *lsu);
-    static void load_float_resume(Lsu *lsu);
+    static void store_resume(void *_this, vp::IoReq *req);
+    static void store_resume(Lsu *lsu, vp::IoReq *req);
+    static void load_resume(Lsu *lsu, vp::IoReq *req);
+    static void elw_resume(Lsu *lsu, vp::IoReq *req);
+    static void load_signed_resume(Lsu *lsu, vp::IoReq *req);
+    static void load_float_resume(Lsu *lsu, vp::IoReq *req);
 
     int64_t pending_latency;
+    // True if the last request has been denied. The core must not send another request until
+    // the last request has been granted
+    bool io_req_denied;
 };

--- a/models/cpu/iss/include/mmu.hpp
+++ b/models/cpu/iss/include/mmu.hpp
@@ -76,7 +76,7 @@ private:
     void walk_pgtab(iss_addr_t virt_addr);
     bool handle_pte();
     static void handle_pte_stub(vp::Block *__this, vp::ClockEvent *event);
-    static void handle_pte_response(Lsu *lsu);
+    static void handle_pte_response(Lsu *lsu, vp::IoReq *req);
     void raise_exception();
 
     Iss &iss;

--- a/models/cpu/iss/riscv.py
+++ b/models/cpu/iss/riscv.py
@@ -100,7 +100,8 @@ class RiscvCommon(st.Component):
             htif=False,
             custom_sources=False,
             float_lib='flexfloat',
-            stack_checker=False
+            stack_checker=False,
+            nb_outstanding=1
         ):
 
         super().__init__(parent, name)
@@ -187,6 +188,9 @@ class RiscvCommon(st.Component):
         self.add_c_flags([f"-DISS_WORD_{self.isa.word_size}"])
 
         self.add_c_flags([f'-DCONFIG_GVSOC_ISS_{core.upper()}=1'])
+
+        if nb_outstanding > 1:
+            self.add_c_flags([f'-DCONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING={nb_outstanding}'])
 
         if supervisor:
             self.add_c_flags(['-DCONFIG_GVSOC_ISS_SUPERVISOR_MODE=1'])

--- a/models/cpu/iss/src/syscalls.cpp
+++ b/models/cpu/iss/src/syscalls.cpp
@@ -117,7 +117,7 @@ void Syscalls::handle_ebreak()
 
 bool Syscalls::user_access(iss_addr_t addr, uint8_t *buffer, iss_addr_t size, bool is_write)
 {
-    vp::IoReq *req = &this->iss.lsu.io_req;
+    vp::IoReq *req = &this->iss.lsu.debug_req;
     std::string str = "";
     while (size != 0)
     {
@@ -160,7 +160,7 @@ bool Syscalls::user_access(iss_addr_t addr, uint8_t *buffer, iss_addr_t size, bo
 
 std::string Syscalls::read_user_string(iss_addr_t addr, int size)
 {
-    vp::IoReq *req = &this->iss.lsu.io_req;
+    vp::IoReq *req = &this->iss.lsu.debug_req;
     std::string str = "";
     while (size != 0)
     {


### PR DESCRIPTION
This adds support for outstanding requests in the ISS.
The core can now send multiple requests without blocking.
This is supported for both synchronous and asynchronous responses but only synchronous reponses has been tested.
Misaligned accesses may not be well supported, to be checked.
Denied requests are also now supported, this is stalling the core immediately until the request is granted.