### PR TITLE
feat(cv32e40p): add CV32E40P ISS core model

### DIFF
--- a/models/cpu/iss/include/core.hpp
+++ b/models/cpu/iss/include/core.hpp
@@ -32,6 +32,9 @@ class Core
 {
 public:
     Core(Iss &iss);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual ~Core() = default;
+#endif
 
     void build();
     void reset(bool active);
@@ -40,6 +43,14 @@ public:
     iss_reg_t dret_handle();
     iss_reg_t sret_handle();
     int mode_get() { return this->mode; }
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    /* Privilege-mode restore on MRET. Default: from mstatus.mpp. */
+    virtual void mret_mode_restore();
+
+    /* mstatus_write_mask customization, called at end of build() after the
+     * generic mask is computed. Default: no-op. */
+    virtual void mstatus_write_mask_fixup() {}
+#endif
     void mode_set(int mode);
     iss_reg_t load_reserve_addr_get() { return this->load_reserve_addr; }
     void load_reserve_addr_set(iss_reg_t addr) { this->load_reserve_addr = addr; }
@@ -50,15 +61,24 @@ public:
     vp::Trace event_jal;
     vp::Trace event_jalr;
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+protected:
+    Iss &iss;
+    iss_reg_t mstatus_write_mask;
+#endif
 private:
     bool mstatus_update(bool is_write, iss_reg_t &value);
     bool sstatus_update(bool is_write, iss_reg_t &value);
 
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     Iss &iss;
+#endif
     vp::Trace trace;
 
     int mode;
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     iss_reg_t mstatus_write_mask;
+#endif
     iss_reg_t sstatus_write_mask;
     iss_reg_t load_reserve_addr;
     bool reset_stall = false;

--- a/models/cpu/iss/include/cores/cv32e40p/class.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/class.hpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+
+#pragma once
+
+
+#include <vp/vp.hpp>
+#include <vp/register.hpp>
+#include <cpu/iss/include/lsu.hpp>
+#include <cpu/iss/include/decode.hpp>
+#include <cpu/iss/include/trace.hpp>
+#include <cpu/iss/include/cores/cv32e40p/csr.hpp>
+#include <cpu/iss/include/dbgunit.hpp>
+#include <cpu/iss/include/cores/cv32e40p/exception.hpp>
+#include <cpu/iss/include/syscalls.hpp>
+#include <cpu/iss/include/timing.hpp>
+#include <cpu/iss/include/cores/cv32e40p/regfile.hpp>
+#ifdef CONFIG_GVSOC_ISS_RISCV_EXCEPTIONS
+#include <cpu/iss/include/cores/cv32e40p/irq.hpp>
+#else
+#include <cpu/iss/include/irq/irq_external.hpp>
+#endif
+#include <cpu/iss/include/cores/cv32e40p/core.hpp>
+#if defined(CONFIG_GVSOC_ISS_MMU)
+#include <cpu/iss/include/mmu.hpp>
+#endif
+#if defined(CONFIG_GVSOC_ISS_PMP)
+#include <cpu/iss/include/pmp.hpp>
+#endif
+#include <cpu/iss/include/memcheck.hpp>
+#include <cpu/iss/include/insn_cache.hpp>
+#include <cpu/iss/include/exec/exec_inorder.hpp>
+#include <cpu/iss/include/prefetch/prefetch_single_line.hpp>
+#include <cpu/iss/include/gdbserver.hpp>
+
+class IssWrapper;
+
+
+class Iss
+{
+public:
+    Iss(IssWrapper &top);
+
+    Cv32e40pRegfile regfile;
+    Exec exec;
+    InsnCache insn_cache;
+    Timing timing;
+    Cv32e40pCore core;
+    Prefetcher prefetcher;
+    Decode decode;
+    Cv32e40pIrq irq;
+    Gdbserver gdbserver;
+    Lsu lsu;
+    DbgUnit dbgunit;
+    Syscalls syscalls;
+    Trace trace;
+    Cv32e40pCsr csr;
+#if defined(CONFIG_GVSOC_ISS_MMU)
+    Mmu mmu;
+#endif
+#if defined(CONFIG_GVSOC_ISS_PMP)
+    Pmp pmp;
+#endif
+    Cv32e40pException exception;
+    Memcheck memcheck;
+
+    vp::Component &top;
+};
+
+class IssWrapper : public vp::Component
+{
+
+public:
+    IssWrapper(vp::ComponentConf &config);
+
+    void start();
+    void stop();
+    void reset(bool active);
+
+    Iss iss;
+
+private:
+    vp::Trace trace;
+};
+
+inline Iss::Iss(IssWrapper &top)
+    : prefetcher(*this), exec(top, *this), insn_cache(*this), decode(*this), timing(*this), core(*this), irq(*this),
+      gdbserver(*this), lsu(top, *this), dbgunit(*this), syscalls(top, *this), trace(*this), csr(*this),
+      regfile(top, *this), exception(*this), memcheck(top, *this), top(top)
+#if defined(CONFIG_GVSOC_ISS_MMU)
+    , mmu(*this)
+#endif
+#if defined(CONFIG_GVSOC_ISS_PMP)
+    , pmp(*this)
+#endif
+{
+}
+
+#include "cpu/iss/include/isa/rv64i.hpp"
+#include "cpu/iss/include/isa/rv32i.hpp"
+#include "cpu/iss/include/isa/rv32c.hpp"
+#include "cpu/iss/include/isa/zcmp.hpp"
+#include "cpu/iss/include/isa/rv32a.hpp"
+#include "cpu/iss/include/isa/rv64c.hpp"
+#include "cpu/iss/include/isa/rv32m.hpp"
+#include "cpu/iss/include/isa/rv64m.hpp"
+#include "cpu/iss/include/isa/rv64a.hpp"
+#include "cpu/iss/include/isa/rvf.hpp"
+#include "cpu/iss/include/isa/rvd.hpp"
+#include "cpu/iss/include/cores/cv32e40p/priv.hpp"
+#include <cpu/iss/include/isa/corev.hpp>
+
+
+#include <cpu/iss/include/exec/exec_inorder_implem.hpp>

--- a/models/cpu/iss/include/cores/cv32e40p/core.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/core.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#pragma once
+
+#include <cpu/iss/include/core.hpp>
+
+class Cv32e40pCore : public Core
+{
+public:
+    Cv32e40pCore(Iss &iss) : Core(iss) {}
+
+protected:
+    /* CV32E40P is M-mode only.
+     * CSR writes can set MPP to 0, but
+     * MRET must ignore that and stay in M-mode. */
+    void mret_mode_restore() override;
+
+    /* CV32E40P mstatus_write_mask FPU-aware.
+     * only MIE(3) + MPIE(7) writable; MPP forced to M by hardware.
+     * With FPU: add FS(14:13). */
+    void mstatus_write_mask_fixup() override;
+};

--- a/models/cpu/iss/include/cores/cv32e40p/csr.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/csr.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#pragma once
+
+#include <cpu/iss/include/csr.hpp>
+
+class Cv32e40pCsr : public Csr
+{
+public:
+    Cv32e40pCsr(Iss &iss);
+
+    void build();           // Calls Csr::build() then build_cv32e40p()
+    void build_cv32e40p();  // CV32E40P-specific CSR customization
+    void reset(bool active);
+
+    bool mstatus_access(bool is_write, iss_reg_t &value) override;
+    bool mcycle_access(bool is_write, iss_reg_t &value) override;
+    void mstatus_read_fixup(iss_reg_t &value) override;
+
+    // FP/Vector CSR access pre-check.
+    // Returns true (illegal) when mstatus[FS] == 00 (Off)
+    // raises illegal-instruction on FP CSR access while FS=Off.
+    bool fp_access_illegal() override;
+
+    // CoreV2 HWLOOP CSR mapping.
+    //   0xCC0..0xCC2 → 0..2  (lpstart0/lpend0/lpcount0)
+    //   0xCC4..0xCC6 → 4..6  (lpstart1/lpend1/lpcount1)
+    //   gap at 0xCC3 / outside range → -1.
+    int hwloop_csr_index(iss_reg_t reg) override;
+
+    // CoreV2 HWLOOP CSR names for trace messages.
+    const char *custom_csr_name(iss_reg_t reg) override;
+
+    // EBREAK in M-mode enters debug when dcsr.ebreakm=1.
+    // RISC-V Debug Spec §3.1.2 — bit 15 of dcsr is ebreakm.
+    bool ebreak_m_mode_enters_debug() override;
+
+    // PULP custom CSRs (0xCD0-0xCD2)
+    CsrReg uhartid;     // 0xCD0 — duplicate of mhartid (user-mode readable)
+    CsrReg privlv;      // 0xCD1 — current privilege level
+    CsrReg zfinx_csr;   // 0xCD2 — ZFINX indicator (1 if FPU+ZFINX, else 0)
+
+private:
+    int64_t mcycle_offset = 0;
+    bool m_fpu_in_isa = false;
+    bool m_zfinx = false;
+};

--- a/models/cpu/iss/include/cores/cv32e40p/exception.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/exception.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#pragma once
+
+#include <cpu/iss/include/exception.hpp>
+
+class Cv32e40pException : public Exception
+{
+public:
+    /* CV32E40P always aligns the trap vector to 4 bytes
+    set base-class alignment mask accordingly. */
+    Cv32e40pException(Iss &iss) : Exception(iss)
+    {
+        this->trap_vector_align_mask = ~(iss_reg_t)0x3;
+    }
+};

--- a/models/cpu/iss/include/cores/cv32e40p/irq.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/irq.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#pragma once
+
+#include <cpu/iss/include/irq/irq_riscv.hpp>
+
+class Cv32e40pIrq : public Irq
+{
+public:
+    Cv32e40pIrq(Iss &iss) : Irq(iss) {}
+
+    bool mip_access(bool is_write, iss_reg_t &value) override;
+    bool mie_access(bool is_write, iss_reg_t &value) override;
+    bool mtvec_access(bool is_write, iss_reg_t &value) override;
+    void elw_irq_unstall() override;
+
+protected:
+    void register_csr_callbacks() override;
+};

--- a/models/cpu/iss/include/cores/cv32e40p/priv.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/priv.hpp
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+/*
+ * CV32E40P-specific override of isa/priv.hpp.
+ *
+ * Fixes CSRRC/CSRRCI/CSRRSI to NOT treat rs1=x0 / uimm=0 as a write, per
+ * RISC-V Privileged Spec §2.2:
+ *   "If rs1=x0, then the instruction shall not write to the CSR at all."
+ *   "For CSRRSI/CSRRCI, if uimm=0, the instruction shall not write the CSR."
+ *
+ * csrrs_exec is already correct upstream and is reproduced verbatim below.
+ */
+
+#pragma once
+
+#include <cpu/iss/include/iss_core.hpp>
+
+static inline void csr_decode(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // In case traces are active, convert the CSR number into a name
+#ifdef VP_TRACE_ACTIVE
+    insn->args[2].flags = (iss_decoder_arg_flag_e)(insn->args[2].flags | ISS_DECODER_ARG_FLAG_DUMP_NAME);
+    insn->args[2].name = iss_csr_name(iss, UIM_GET(0));
+#endif
+}
+
+static inline iss_reg_t csrrw_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+
+    CsrAbtractReg *csr = iss->csr.get_csr(UIM_GET(0));
+    if (csr)
+    {
+        return csr->handle(iss, insn, pc, REG_GET(0));
+    }
+
+    iss_reg_t value;
+    iss_reg_t reg_value = REG_GET(0);
+
+    if (iss_csr_read(iss, insn, UIM_GET(0), &value) == 0)
+    {
+        if (insn->out_regs[0] != 0)
+        {
+            // For now we don't have any mechanism to track validity of CSR, so set output
+            // register as valid
+            iss->regfile.memcheck_set_valid(REG_OUT(0), true);
+            REG_SET(0, value);
+        }
+    }
+
+    iss_csr_write(iss, insn, UIM_GET(0), reg_value);
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+/*
+ * csrrc_exec — CV32E40P fix: CSRRC with rs1=x0 must NOT write the CSR.
+ * RISC-V Priv Spec §2.2: if rs1=x0 the instruction shall not write to the CSR.
+ */
+static inline iss_reg_t csrrc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t value;
+    iss_reg_t reg_value = REG_GET(0);
+
+    CsrAbtractReg *csr = iss->csr.get_csr(UIM_GET(0));
+    if (csr && !csr->check_access(iss, REG_IN(0) != 0, true))
+    {
+        return pc;
+    }
+
+    if (iss_csr_read(iss, insn, UIM_GET(0), &value) == 0)
+    {
+        if (insn->out_regs[0] != 0)
+        {
+            // For now we don't have any mechanism to track validity of CSR, so set output
+            // register as valid
+            iss->regfile.memcheck_set_valid(REG_OUT(0), true);
+            REG_SET(0, value);
+        }
+    }
+
+    if (REG_IN(0) != 0)
+    {
+        iss_csr_write(iss, insn, UIM_GET(0), value & ~reg_value);
+    }
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t csrrs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t value;
+    iss_reg_t reg_value = REG_GET(0);
+
+    #ifdef CONFIG_GVSOC_ISS_SNITCH
+    // Todo: put csr mcycle performance couter value assignment from here to csr.cpp
+    if (UIM_GET(0) == 0xB00)
+    {
+        iss->csr.mcycle.value = iss->top.clock.get_cycles();
+    }
+    #endif
+
+    CsrAbtractReg *csr = iss->csr.get_csr(UIM_GET(0));
+    if (csr && !csr->check_access(iss, REG_IN(0) != 0, true))
+    {
+        return pc;
+    }
+
+    if (iss_csr_read(iss, insn, UIM_GET(0), &value) == 0)
+    {
+        if (insn->out_regs[0] != 0)
+        {
+            // For now we don't have any mechanism to track validity of CSR, so set output
+            // register as valid
+            iss->regfile.memcheck_set_valid(REG_OUT(0), true);
+            REG_SET(0, value);
+        }
+    }
+    if (REG_IN(0) != 0)
+    {
+        iss_csr_write(iss, insn, UIM_GET(0), value | reg_value);
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t csrrwi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t value;
+
+    CsrAbtractReg *csr = iss->csr.get_csr(UIM_GET(0));
+    if (csr)
+    {
+        return csr->handle(iss, insn, pc, UIM_GET(1));
+    }
+
+    if (iss_csr_read(iss, insn, UIM_GET(0), &value) == 0)
+    {
+        if (insn->out_regs[0] != 0)
+        {
+            // For now we don't have any mechanism to track validity of CSR, so set output
+            // register as valid
+            iss->regfile.memcheck_set_valid(REG_OUT(0), true);
+            REG_SET(0, value);
+        }
+    }
+    iss_csr_write(iss, insn, UIM_GET(0), UIM_GET(1));
+    return iss_insn_next(iss, insn, pc);
+}
+
+/*
+ * csrrci_exec — CV32E40P fix: CSRRCI with uimm=0 must NOT write the CSR.
+ * RISC-V Priv Spec §2.2: for CSRRCI, if uimm[4:0]=0 the instruction shall not write the CSR.
+ */
+static inline iss_reg_t csrrci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t value;
+
+    CsrAbtractReg *csr = iss->csr.get_csr(UIM_GET(0));
+    if (csr && !csr->check_access(iss, UIM_GET(1) != 0, true))
+    {
+        return pc;
+    }
+
+    if (iss_csr_read(iss, insn, UIM_GET(0), &value) == 0)
+    {
+        if (insn->out_regs[0] != 0)
+        {
+            // For now we don't have any mechanism to track validity of CSR, so set output
+            // register as valid
+            iss->regfile.memcheck_set_valid(REG_OUT(0), true);
+            REG_SET(0, value);
+        }
+    }
+
+    if (UIM_GET(1) != 0)
+    {
+        iss_csr_write(iss, insn, UIM_GET(0), value & ~UIM_GET(1));
+    }
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+/*
+ * csrrsi_exec — CV32E40P fix: CSRRSI with uimm=0 must NOT write the CSR.
+ * RISC-V Priv Spec §2.2: for CSRRSI, if uimm[4:0]=0 the instruction shall not write the CSR.
+ */
+static inline iss_reg_t csrrsi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t value;
+
+    CsrAbtractReg *csr = iss->csr.get_csr(UIM_GET(0));
+    if (csr && !csr->check_access(iss, UIM_GET(1) != 0, true))
+    {
+        return pc;
+    }
+
+    if (iss_csr_read(iss, insn, UIM_GET(0), &value) == 0)
+    {
+        if (insn->out_regs[0] != 0)
+        {
+            // For now we don't have any mechanism to track validity of CSR, so set output
+            // register as valid
+            iss->regfile.memcheck_set_valid(REG_OUT(0), true);
+            REG_SET(0, value);
+        }
+    }
+
+    if (UIM_GET(1) != 0)
+    {
+        iss_csr_write(iss, insn, UIM_GET(0), value | UIM_GET(1));
+    }
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t wfi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->irq.wfi_handle();
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t mret_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->exec.irq_exit.set(1);
+    iss->timing.stall_insn_dependency_account(5);
+    return iss->core.mret_handle();
+}
+
+static inline iss_reg_t dret_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return iss->core.dret_handle();
+}
+
+static inline iss_reg_t sret_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->timing.stall_insn_dependency_account(5);
+    return iss->core.sret_handle();
+}
+
+static inline iss_reg_t sfence_vma_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->core.mode_get() == PRIV_S && iss->csr.mstatus.tvm)
+    {
+        iss->exception.raise(pc, ISS_EXCEPT_ILLEGAL);
+        return pc;
+    }
+    else
+    {
+#ifdef CONFIG_GVSOC_ISS_MMU
+        iss->mmu.flush(REG_GET(0), REG_GET(1));
+#endif
+        iss->insn_cache.mode_flush();
+        return iss_insn_next(iss, insn, pc);
+    }
+}

--- a/models/cpu/iss/include/cores/cv32e40p/regfile.hpp
+++ b/models/cpu/iss/include/cores/cv32e40p/regfile.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+
+#pragma once
+
+#include <cpu/iss/include/regfile.hpp>
+
+
+class Cv32e40pRegfile : public Regfile
+{
+public:
+    Cv32e40pRegfile(IssWrapper &top, Iss &iss) : Regfile(top, iss) {}
+
+    void reset(bool active) { 
+           Regfile::reset(active);
+           for (int i = 0; i < ISS_NB_REGS; i++) this->regs[i] = 0; 
+        }
+
+};

--- a/models/cpu/iss/include/csr.hpp
+++ b/models/cpu/iss/include/csr.hpp
@@ -52,12 +52,23 @@ public:
 
     const char *name;
     iss_reg_t reset_val;
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    iss_reg_t write_mask;
+#endif
     bool write_illegal = false;
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+
+    // Public setter for write_mask — allows core-specific subclasses to
+    // configure CSR masks without requiring friend access.
+    void set_write_mask(iss_reg_t mask) { write_mask = mask; }
+#endif
 
 protected:
     void reset(bool active);
 
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     iss_reg_t write_mask;
+#endif
 
 private:
     std::vector<std::function<bool(bool, iss_reg_t &)>> callbacks;
@@ -152,6 +163,9 @@ public:
 
     void build();
     void reset(bool active);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual ~Csr() = default;
+#endif
 
     void declare_pcer(int index, std::string name, std::string help);
     void declare_csr(CsrAbtractReg *reg, std::string name, iss_reg_t address, iss_reg_t reset_val=0, iss_reg_t mask=-1);
@@ -214,6 +228,22 @@ public:
 #endif
     CsrReg mcountinhibit;
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Optional extension CSRs (CV32E40P-only).
+    // When the config is off, access falls through to the "unsupported CSR" warning.
+#if ISS_REG_WIDTH == 32
+    CsrReg mcycleh;
+    CsrReg minstreth;
+#endif
+
+    CsrReg minstret;
+    CsrReg mhpmevent[29];
+
+    CsrReg tinfo;
+    CsrReg mcontext;
+    CsrReg scontext;
+
+#endif /* CONFIG_GVSOC_ISS_CV32E40P */
 #if defined(CONFIG_GVSOC_ISS_PMP)
     CsrReg pmpcfg[16];
     CsrReg pmpaddr[64];
@@ -236,7 +266,12 @@ public:
     iss_reg_t scratch0;
     iss_reg_t scratch1;
     iss_fcsr_t fcsr;
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    CsrReg mhartid;
+    CsrReg mimpid;
+#else
     iss_reg_t mhartid;
+#endif
 
     CsrReg vstart;
     CsrReg vxstat;
@@ -250,6 +285,60 @@ public:
     iss_reg_t hwloop_regs[HWLOOP_NB_REGS];
 #endif
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    /* Hook for core-specific mstatus read fixup (e.g. SD bit).
+     * Called by Core::mstatus_update on read path. Default: no-op. */
+    virtual void mstatus_read_fixup(iss_reg_t &value) {}
+
+    /* FP/Vector CSR access pre-check.
+     * Default: allow (returns false → not illegal).
+     * Called from static fflags/frm/fcsr read/write to detect illegal access. */
+    virtual bool fp_access_illegal() { return false; }
+
+    /* Default tselect read value when no trigger is selected.
+     * Default: -1 (all-1s, conventional "no trigger" sentinel). */
+    iss_reg_t tselect_default_read = (iss_reg_t)-1;
+
+    /* Behavior on access to an undeclared/unsupported CSR.
+     * Default: false → log warning, no exception (legacy GVSOC behavior). */
+    bool raise_on_unsupported_csr_flag = false;
+
+    /* Map a CSR address to its core-specific HWLOOP register index.
+     * Default: -1 (not a HWLOOP CSR).
+     * Used by iss_csr_read (dispatch to hwloop_read) and iss_csr_write. */
+    virtual int hwloop_csr_index(iss_reg_t reg) { return -1; }
+
+    /* Core-specific CSR name lookup for trace messages.
+     * Default: nullptr (fall through to generic table). */
+    virtual const char *custom_csr_name(iss_reg_t reg) { return nullptr; }
+
+    /* Whether Exec::bootaddr_apply derives mtvec from boot address.
+     * Default: true (generic RISC-V: mtvec = bootaddr & ~0xFF). */
+    bool bootaddr_writes_mtvec_flag = true;
+
+    /* EBREAK in M-mode behavior.
+     * Default: false → raise ISS_EXCEPT_BREAKPOINT (generic RISC-V w/o debug). */
+    virtual bool ebreak_m_mode_enters_debug() { return false; }
+
+protected:
+    /* mstatus access hook.
+     * Default: pass through (return true). */
+    virtual bool mstatus_access(bool is_write, iss_reg_t &value);
+    /* mcycle access hook.
+     * Default: on read, return current clock cycle count; on write, no-op. */
+    virtual bool mcycle_access(bool is_write, iss_reg_t &value);
+    void undeclare_csr(iss_reg_t address) { regs.erase(address); }
+
+    std::map<iss_reg_t, CsrAbtractReg *> regs;
+
+private:
+
+    bool tselect_access(bool is_write, iss_reg_t &value);
+    bool time_access(bool is_write, iss_reg_t &value);
+    vp::WireMaster<uint64_t> time_itf;
+
+};
+#else
 private:
 
     bool tselect_access(bool is_write, iss_reg_t &value);
@@ -260,3 +349,4 @@ private:
     vp::WireMaster<uint64_t> time_itf;
 
 };
+#endif

--- a/models/cpu/iss/include/exception.hpp
+++ b/models/cpu/iss/include/exception.hpp
@@ -28,6 +28,9 @@ class Exception
 {
 public:
     Exception(Iss &iss);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual ~Exception() = default;
+#endif
 
     void build();
 
@@ -35,7 +38,17 @@ public:
 
     iss_addr_t debug_handler_addr;
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+protected:
+#else
 private:
+#endif
     Iss &iss;
     vp::Trace trace;
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+
+    /* Trap vector PC alignment mask.
+     * Default: -1 (no masking — generic RISC-V). */
+    iss_reg_t trap_vector_align_mask = (iss_reg_t)-1;
+#endif
 };

--- a/models/cpu/iss/include/irq/irq_riscv.hpp
+++ b/models/cpu/iss/include/irq/irq_riscv.hpp
@@ -44,15 +44,27 @@ class Irq
 {
 public:
     Irq(Iss &iss);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual ~Irq() = default;
+#endif
 
     void build();
 
     bool mideleg_access(bool is_write, iss_reg_t &value);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual bool mip_access(bool is_write, iss_reg_t &value);
+    virtual bool mie_access(bool is_write, iss_reg_t &value);
+#else
     bool mip_access(bool is_write, iss_reg_t &value);
     bool mie_access(bool is_write, iss_reg_t &value);
+#endif
     bool sip_access(bool is_write, iss_reg_t &value);
     bool sie_access(bool is_write, iss_reg_t &value);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual bool mtvec_access(bool is_write, iss_reg_t &value);
+#else
     bool mtvec_access(bool is_write, iss_reg_t &value);
+#endif
     bool stvec_access(bool is_write, iss_reg_t &value);
 
     bool mtvec_set(iss_addr_t base);
@@ -62,8 +74,21 @@ public:
     void reset(bool active);
     int check();
     void wfi_handle();
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    virtual void elw_irq_unstall();
+#else
     void elw_irq_unstall();
+#endif
     void check_interrupts();
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+
+protected:
+    /* Register CSR access callbacks (mip/mie/mtvec).
+     * Default: registers handlers for mip, mie, mtvec on the base Csr class. */
+    virtual void register_csr_callbacks();
+
+public:
+#endif
     static void msi_sync(vp::Block *__this, bool value);
     static void mti_sync(vp::Block *__this, bool value);
     static void mei_sync(vp::Block *__this, bool value);

--- a/models/cpu/iss/include/isa/corev.hpp
+++ b/models/cpu/iss/include/isa/corev.hpp
@@ -27,13 +27,13 @@
 #define COREV_HWLOOP_LPEND0 1
 #define COREV_HWLOOP_LPCOUNT0 2
 
-#define COREV_HWLOOP_LPSTART1 3
-#define COREV_HWLOOP_LPEND1 4
-#define COREV_HWLOOP_LPCOUNT1 5
+#define COREV_HWLOOP_LPSTART1 4
+#define COREV_HWLOOP_LPEND1 5
+#define COREV_HWLOOP_LPCOUNT1 6
 
-#define COREV_HWLOOP_LPSTART(x) (COREV_HWLOOP_LPSTART0 + (x)*3)
-#define COREV_HWLOOP_LPEND(x) (COREV_HWLOOP_LPEND0 + (x)*3)
-#define COREV_HWLOOP_LPCOUNT(x) (COREV_HWLOOP_LPCOUNT0 + (x)*3)
+#define COREV_HWLOOP_LPSTART(x) (COREV_HWLOOP_LPSTART0 + (x)*4)
+#define COREV_HWLOOP_LPEND(x) (COREV_HWLOOP_LPEND0 + (x)*4)
+#define COREV_HWLOOP_LPCOUNT(x) (COREV_HWLOOP_LPCOUNT0 + (x)*4)
 
 static inline iss_reg_t corev_hwloop_check_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
@@ -41,9 +41,15 @@ static inline iss_reg_t corev_hwloop_check_exec(Iss *iss, iss_insn_t *insn, iss_
     // time it is executed
     bool elw_interrupted = iss->exec.elw_interrupted;
 
-    // First execute the instructions as it is the last one of the loop body.
+    // First execute the instruction as it is the last one of the loop body.
     // The real handler has been saved when the loop was started.
     iss_reg_t insn_next = insn->hwloop_handler(iss, insn, pc);
+
+    // If halted (e.g. by elw stall), do not process hwloop logic
+    if (iss->exec.halted.get())
+    {
+        return insn_next;
+    }
 
     if (elw_interrupted)
     {
@@ -93,35 +99,13 @@ static inline iss_reg_t corev_hwloop_check_exec(Iss *iss, iss_insn_t *insn, iss_
 static inline void corev_hwloop_set_start(Iss *iss, iss_insn_t *insn, int index, iss_reg_t start)
 {
     iss->csr.hwloop_regs[COREV_HWLOOP_LPSTART(index)] = start;
-    iss->exec.hwloop_start_insn[index] = start;
-}
-
-static inline void corev_hwloop_set_insn_end(Iss *iss, iss_reg_t pc)
-{
-    // TODO INSN
-    abort();
-    // if (insn->fetched)
-    // {
-    //     if (insn->hwloop_handler == NULL)
-    //     {
-    //         insn->hwloop_handler = insn->handler;
-    //         insn->handler = hwloop_check_exec;
-    //         insn->fast_handler = hwloop_check_exec;
-    //     }
-    // }
-    // else
-    // {
-    //     insn->hwloop_handler = hwloop_check_exec;
-    // }
+    iss->exec.hwloop_set_start(index, start);
 }
 
 static inline void corev_hwloop_set_end(Iss *iss, iss_insn_t *insn, int index, iss_reg_t end)
 {
-    iss->exec.hwloop_end_insn[index] = end;
-
-    corev_hwloop_set_insn_end(iss, end);
-
     iss->csr.hwloop_regs[COREV_HWLOOP_LPEND(index)] = end;
+    iss->exec.hwloop_set_end(index, end);
 }
 
 static inline void corev_hwloop_set_count(Iss *iss, iss_insn_t *insn, int index, iss_reg_t count)
@@ -136,912 +120,48 @@ static inline void corev_hwloop_set_all(Iss *iss, iss_insn_t *insn, int index, i
     corev_hwloop_set_count(iss, insn, index, count);
 }
 
-static inline iss_reg_t cv_avgu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+/* Dead cv_* scalar handlers removed — the decoder (isa_cv32e40pv2.py) uses
+ * p_* names from the PulpV2 section below. The cv_* versions were unused
+ * duplicates (L= parameter only sets trace label, not handler name). */
+
+/* iss_handle_elw from pulp_v2.hpp — needed by cv_elw_exec and p_elw_exec */
+#ifndef CONFIG_GVSOC_ISS_V2
+static inline void iss_handle_elw(Iss *iss, iss_insn_t *insn, iss_reg_t pc, iss_addr_t addr, int size, int reg)
 {
-    REG_SET(0, LIB_CALL2(lib_AVGU, REG_GET(0), REG_GET(1)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
+    // Always account the overhead of the elw
+    iss->timing.stall_insn_account(2);
 
-static inline iss_reg_t cv_slet_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, (int32_t)REG_GET(0) <= (int32_t)REG_GET(1));
-    return iss_insn_next(iss, insn, pc);
-}
+    iss->exec.elw_insn = pc;
+    // Init this flag so that we can check afterwards that theelw has been replayed
+    iss->exec.elw_interrupted = 0;
 
-static inline iss_reg_t cv_sletu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, REG_GET(0) <= REG_GET(1));
-    return iss_insn_next(iss, insn, pc);
-}
+    iss->lsu.elw_perf(insn, addr, size, reg);
 
-static inline iss_reg_t cv_min_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MINS, REG_GET(0), REG_GET(1)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_minu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MINU, REG_GET(0), REG_GET(1)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_max_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MAXS, REG_GET(0), REG_GET(1)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_maxu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MAXU, REG_GET(0), REG_GET(1)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_ror_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_ROR, REG_GET(0), REG_GET(1)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_ff1_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL1(lib_FF1, REG_GET(0)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_fl1_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL1(lib_FL1, REG_GET(0)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_clb_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL1(lib_CLB, REG_GET(0)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_cnt_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL1(lib_CNT, REG_GET(0)));
-    // setRegDelayed(cpu, pc->outReg[0], value, 2);
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_exths_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, iss_get_signed_value(REG_GET(0), 16));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_exthz_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, iss_get_field(REG_GET(0), 0, 16));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_extbs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, iss_get_signed_value(REG_GET(0), 8));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_extbz_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, iss_get_field(REG_GET(0), 0, 8));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_starti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    corev_hwloop_set_start(iss, insn, UIM_GET(0), pc + (UIM_GET(1) << 1));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_endi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    corev_hwloop_set_end(iss, insn, UIM_GET(0), pc + (UIM_GET(1) << 1));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_count_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    corev_hwloop_set_count(iss, insn, UIM_GET(0), REG_GET(0));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_counti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    corev_hwloop_set_count(iss, insn, UIM_GET(0), UIM_GET(1));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_setup_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    int index = UIM_GET(0);
-    iss_reg_t count = REG_GET(0);
-    iss_reg_t start = pc + insn->size;
-    iss_reg_t end = pc + (UIM_GET(1) << 1);
-
-    corev_hwloop_set_all(iss, insn, index, start, end, count);
-
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_setupi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    int index = UIM_GET(0);
-    iss_reg_t count = UIM_GET(1);
-    iss_reg_t start = pc + insn->size;
-    iss_reg_t end = pc + (UIM_GET(2) << 1);
-
-    corev_hwloop_set_all(iss, insn, index, start, end, count);
-
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_abs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL1(lib_ABS, REG_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_elw_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    iss_handle_elw(iss, insn, pc, REG_GET(0) + SIM_GET(0), 4, REG_OUT(0));
-    return iss_insn_next(iss, insn, pc);
-}
-
-#define CV_OP_RS_EXEC(insn_name, lib_name)                                                         \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                  \
-    {                                                                                              \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_int16_t_to_int32_t, REG_GET(0), REG_GET(1)));    \
-        return iss_insn_next(iss, insn, pc);                                                                         \
-    }                                                                                              \
-                                                                                                   \
-    static inline iss_reg_t cv_##insn_name##_sc_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)               \
-    {                                                                                              \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int16_t_to_int32_t, REG_GET(0), REG_GET(1))); \
-        return iss_insn_next(iss, insn, pc);                                                                         \
-    }                                                                                              \
-                                                                                                   \
-    static inline iss_reg_t cv_##insn_name##_sci_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
-    {                                                                                              \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int16_t_to_int32_t, REG_GET(0), SIM_GET(0))); \
-        return iss_insn_next(iss, insn, pc);                                                                         \
-    }                                                                                              \
-                                                                                                   \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                  \
-    {                                                                                              \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_int8_t_to_int32_t, REG_GET(0), REG_GET(1)));     \
-        return iss_insn_next(iss, insn, pc);                                                                         \
-    }                                                                                              \
-                                                                                                   \
-    static inline iss_reg_t cv_##insn_name##_sc_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)               \
-    {                                                                                              \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int8_t_to_int32_t, REG_GET(0), REG_GET(1)));  \
-        return iss_insn_next(iss, insn, pc);                                                                         \
-    }                                                                                              \
-                                                                                                   \
-    static inline iss_reg_t cv_##insn_name##_sci_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
-    {                                                                                              \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int8_t_to_int32_t, REG_GET(0), SIM_GET(0)));  \
-        return iss_insn_next(iss, insn, pc);                                                                         \
-    }
-
-#define CV_OP_RU_EXEC(insn_name, lib_name)                                                           \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                    \
-    {                                                                                                \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_uint16_t_to_uint32_t, REG_GET(0), REG_GET(1)));    \
-        return iss_insn_next(iss, insn, pc);                                                                           \
-    }                                                                                                \
-                                                                                                     \
-    static inline iss_reg_t cv_##insn_name##_sc_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                 \
-    {                                                                                                \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint16_t_to_uint32_t, REG_GET(0), REG_GET(1))); \
-        return iss_insn_next(iss, insn, pc);                                                                           \
-    }                                                                                                \
-                                                                                                     \
-    static inline iss_reg_t cv_##insn_name##_sci_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                \
-    {                                                                                                \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint16_t_to_uint32_t, REG_GET(0), UIM_GET(0))); \
-        return iss_insn_next(iss, insn, pc);                                                                           \
-    }                                                                                                \
-                                                                                                     \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                    \
-    {                                                                                                \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_uint8_t_to_uint32_t, REG_GET(0), REG_GET(1)));     \
-        return iss_insn_next(iss, insn, pc);                                                                           \
-    }                                                                                                \
-                                                                                                     \
-    static inline iss_reg_t cv_##insn_name##_sc_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                 \
-    {                                                                                                \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint8_t_to_uint32_t, REG_GET(0), REG_GET(1)));  \
-        return iss_insn_next(iss, insn, pc);                                                                           \
-    }                                                                                                \
-                                                                                                     \
-    static inline iss_reg_t cv_##insn_name##_sci_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                \
-    {                                                                                                \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint8_t_to_uint32_t, REG_GET(0), UIM_GET(0)));  \
-        return iss_insn_next(iss, insn, pc);                                                                           \
-    }
-
-#define CV_OP_RS_EXEC2(insn_name, lib_name)                                           \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_16, REG_GET(0), REG_GET(1)));       \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1)));    \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), SIM_GET(0)));    \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_8, REG_GET(0), REG_GET(1)));        \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1)));     \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), SIM_GET(0)));     \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }
-
-#define CV_OP_RU_EXEC2(insn_name, lib_name)                                           \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_16, REG_GET(0), REG_GET(1)));       \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1)));    \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), UIM_GET(0)));    \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_8, REG_GET(0), REG_GET(1)));        \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1)));     \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }                                                                                 \
-                                                                                      \
-    static inline iss_reg_t cv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
-    {                                                                                 \
-        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), UIM_GET(0)));     \
-        return iss_insn_next(iss, insn, pc);                                                            \
-    }
-
-#define CV_OP_RRS_EXEC2(insn_name, lib_name)                                                   \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_16, REG_GET(2), REG_GET(0), REG_GET(1)));    \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(2), REG_GET(0), REG_GET(1))); \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1), SIM_GET(0))); \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_8, REG_GET(2), REG_GET(0), REG_GET(1)));     \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(2), REG_GET(0), REG_GET(1)));  \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1), SIM_GET(0)));  \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }
-
-#define CV_OP_RRU_EXEC2(insn_name, lib_name)                                                   \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_16, REG_GET(2), REG_GET(0), REG_GET(1)));    \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(2), REG_GET(0), REG_GET(1))); \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1), UIM_GET(0))); \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_8, REG_GET(2), REG_GET(0), REG_GET(1)));     \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(2), REG_GET(0), REG_GET(1)));  \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }                                                                                          \
-                                                                                               \
-    static inline iss_reg_t cv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
-    {                                                                                          \
-        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1), UIM_GET(0)));  \
-        return iss_insn_next(iss, insn, pc);                                                                     \
-    }
-
-#define CV_OP1_RS_EXEC(insn_name, lib_name)                                         \
-    static inline iss_reg_t cv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)   \
-    {                                                                               \
-        REG_SET(0, LIB_CALL1(lib_VEC_##lib_name##_int16_t_to_int32_t, REG_GET(0))); \
-        return iss_insn_next(iss, insn, pc);                                                          \
-    }                                                                               \
-                                                                                    \
-    static inline iss_reg_t cv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)   \
-    {                                                                               \
-        REG_SET(0, LIB_CALL1(lib_VEC_##lib_name##_int8_t_to_int32_t, REG_GET(0)));  \
-        return iss_insn_next(iss, insn, pc);                                                          \
-    }
-
-CV_OP_RS_EXEC(add, ADD)
-
-CV_OP_RS_EXEC(sub, SUB)
-
-CV_OP_RS_EXEC(avg, AVG)
-
-CV_OP_RU_EXEC(avgu, AVGU)
-
-CV_OP_RS_EXEC(min, MIN)
-
-CV_OP_RU_EXEC(minu, MINU)
-
-CV_OP_RS_EXEC(max, MAX)
-
-CV_OP_RU_EXEC(maxu, MAXU)
-
-CV_OP_RU_EXEC(srl, SRL)
-
-CV_OP_RS_EXEC(sra, SRA)
-
-CV_OP_RU_EXEC(sll, SLL)
-
-CV_OP_RS_EXEC(or, OR)
-
-CV_OP_RS_EXEC(xor, XOR)
-
-CV_OP_RS_EXEC(and, AND)
-
-CV_OP1_RS_EXEC(abs, ABS)
-
-static inline iss_reg_t cv_extractr_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_EXT_16, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_extractr_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_EXT_8, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_extractur_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_EXTU_16, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_extractur_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_EXTU_8, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_insertr_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_VEC_INS_16, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_insertr_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_VEC_INS_8, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-CV_OP_RS_EXEC2(dotsp, DOTSP)
-
-CV_OP_RU_EXEC2(dotup, DOTUP)
-
-CV_OP_RS_EXEC2(dotusp, DOTUSP)
-
-CV_OP_RRS_EXEC2(sdotsp, SDOTSP)
-
-CV_OP_RRU_EXEC2(sdotup, SDOTUP)
-
-CV_OP_RRS_EXEC2(sdotusp, SDOTUSP)
-
-static inline iss_reg_t cv_shuffle_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLE_16, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shuffle_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLE_SCI_16, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shuffle_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLE_8, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shufflei0_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI0_SCI_8, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shufflei1_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI1_SCI_8, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shufflei2_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI2_SCI_8, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shufflei3_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI3_SCI_8, REG_GET(0), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shuffle2_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_VEC_SHUFFLE2_16, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_shuffle2_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_VEC_SHUFFLE2_8, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_pack_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_VEC_PACK_SC_16, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_packhi_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_VEC_PACKHI_SC_8, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_packlo_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_VEC_PACKLO_SC_8, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-CV_OP_RS_EXEC(cmpeq, CMPEQ)
-
-CV_OP_RS_EXEC(cmpne, CMPNE)
-
-CV_OP_RS_EXEC(cmpgt, CMPGT)
-
-CV_OP_RS_EXEC(cmpge, CMPGE)
-
-CV_OP_RS_EXEC(cmplt, CMPLT)
-
-CV_OP_RS_EXEC(cmple, CMPLE)
-
-CV_OP_RU_EXEC(cmpgtu, CMPGTU)
-
-CV_OP_RU_EXEC(cmpgeu, CMPGEU)
-
-CV_OP_RU_EXEC(cmpltu, CMPLTU)
-
-CV_OP_RU_EXEC(cmpleu, CMPLEU)
-
-static inline iss_reg_t cv_bneimm_exec_common(Iss *iss, iss_insn_t *insn, iss_reg_t pc, int perf)
-{
-    if ((int32_t)REG_GET(0) != SIM_GET(1))
+    if (!iss->exec.stalled.get())
     {
-#if defined(CONFIG_GVSOC_ISS_V2)
-        iss->timing.event_taken_branch_account();
-#else
-        iss->timing.stall_taken_branch_account();
-#endif
-        return pc + SIM_GET(0);
     }
     else
     {
-        if (perf)
+        // Since an interrupt might have happened during the execution of the elw, we need to check them
+        // in case this is waking-up the elw.
+        if (iss->irq.check())
         {
-            iss->timing.event_branch_account();
+            iss->irq.elw_irq_unstall();
         }
-        return iss_insn_next(iss, insn, pc);
+        else
+        {
+            iss->lsu.elw_stalled.set(true);
+            iss->exec.busy_exit();
+        }
     }
 }
-
-static inline iss_reg_t cv_bneimm_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    return cv_bneimm_exec_common(iss, insn, pc, 0);
-}
-
-static inline iss_reg_t cv_bneimm_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    return cv_bneimm_exec_common(iss, insn, pc, 1);
-}
-
-static inline iss_reg_t cv_beqimm_exec_common(Iss *iss, iss_insn_t *insn, iss_reg_t pc, int perf)
-{
-    if ((int32_t)REG_GET(0) == SIM_GET(1))
-    {
-#if defined(CONFIG_GVSOC_ISS_V2)
-        iss->timing.event_taken_branch_account();
-#else
-        iss->timing.stall_taken_branch_account();
 #endif
-        return pc + SIM_GET(0);
-    }
-    else
-    {
-        if (perf)
-        {
-            iss->timing.event_branch_account();
-        }
-        return iss_insn_next(iss, insn, pc);
-    }
-}
 
-static inline iss_reg_t cv_beqimm_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    return cv_beqimm_exec_common(iss, insn, pc, 0);
-}
 
-static inline iss_reg_t cv_beqimm_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    return cv_beqimm_exec_common(iss, insn, pc, 1);
-}
-
-static inline iss_reg_t cv_mac_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MAC, REG_GET(2), REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_msu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MSU, REG_GET(2), REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mul_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MULS, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_muls_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MUL_SL_SL, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulhhs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MUL_SH_SH, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_SL_SL_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulhhsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_SH_SH_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulsRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_SL_SL_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulhhsRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_SH_SH_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MUL_ZL_ZL, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulhhu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL2(lib_MUL_ZH_ZH, REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_muluN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_ZL_ZL_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulhhuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_ZH_ZH_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_muluRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_ZL_ZL_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_mulhhuRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MUL_ZH_ZH_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_macs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MAC_SL_SL, REG_GET(2), REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_machhs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MAC_SH_SH, REG_GET(2), REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_macsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_SL_SL_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_machhsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_SH_SH_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_macsRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_SL_SL_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_machhsRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_SH_SH_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_macu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MAC_ZL_ZL, REG_GET(2), REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_machhu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_MAC_ZH_ZH, REG_GET(2), REG_GET(0), REG_GET(1)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_macuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_ZL_ZL_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_machhuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_ZH_ZH_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_macuRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_ZL_ZL_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_machhuRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL4(lib_MAC_ZH_ZH_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_addN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_adduN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NRU, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_addRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_adduRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NR_RU, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NRU, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subuRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NR_RU, REG_GET(0), REG_GET(1), UIM_GET(0)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_addNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NR, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_adduNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NRU, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_addRNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NR_R, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_adduRNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_ADD_NR_RU, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NR, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subuNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NRU, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subRNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NR_R, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_subuRNr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    REG_SET(0, LIB_CALL3(lib_SUB_NR_RU, REG_GET(0), REG_GET(1), REG_GET(2)));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_clip_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    int low = (int)-(1 << MAX((int)UIM_GET(0) - 1, 0));
-    int high = (1 << MAX((int)UIM_GET(0) - 1, 0)) - 1;
-    REG_SET(0, LIB_CALL3(lib_CLIP, REG_GET(0), low, high));
-    return iss_insn_next(iss, insn, pc);
-}
-
-static inline iss_reg_t cv_clipu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
-{
-    int low = 0;
-    int high = (1 << MAX((int)UIM_GET(0) - 1, 0)) - 1;
-    REG_SET(0, LIB_CALL3(lib_CLIP, REG_GET(0), low, high));
-    return iss_insn_next(iss, insn, pc);
-}
+/* Dead code removed: cv_elw_exec (decoder uses p_elw_exec),
+ * CV_OP_*_EXEC SIMD macros (CV32E40P has no SIMD v1),
+ * cv_extractr/insertr/shuffle/dot/pack handlers (no decoder refs),
+ * cv_mac/msu/mul/add/sub norm handlers (decoder uses p_* versions). */
 
 static inline iss_reg_t cv_clipr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
 {
@@ -1145,5 +265,2068 @@ static inline iss_reg_t cv_bitrev_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
     REG_SET(0, LIB_CALL3(lib_BITREV, REG_GET(0), UIM_GET(0), UIM_GET(1) + 1));
     return iss_insn_next(iss, insn, pc);
 }
+
+/* p.bitrev label alias — isa_gen derives handler name from label,
+ * so p.bitrev -> p_bitrev_exec; forward to the canonical cv_bitrev_exec. */
+static inline iss_reg_t p_bitrev_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return cv_bitrev_exec(iss, insn, pc);
+}
+
+
+/* lp.start / lp.end: register-based hwloop setup (CV32E40P-specific).
+ * The immediate versions (lp_starti_exec, lp_endi_exec) are in pulp_v2 section below.
+ * These use REG_GET(0) as the address value instead of PC-relative immediate. */
+static inline iss_reg_t lp_start_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    corev_hwloop_set_start(iss, insn, UIM_GET(0), REG_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t lp_end_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    corev_hwloop_set_end(iss, insn, UIM_GET(0), REG_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+/* ================================================================
+ * PULP V2 handlers — ported for CV32E40P independence.
+ * ================================================================ */
+
+#define PULPV2_HWLOOP_LPSTART0 COREV_HWLOOP_LPSTART0
+#define PULPV2_HWLOOP_LPEND0   COREV_HWLOOP_LPEND0
+#define PULPV2_HWLOOP_LPCOUNT0 COREV_HWLOOP_LPCOUNT0
+#define PULPV2_HWLOOP_LPSTART1 COREV_HWLOOP_LPSTART1
+#define PULPV2_HWLOOP_LPEND1   COREV_HWLOOP_LPEND1
+#define PULPV2_HWLOOP_LPCOUNT1 COREV_HWLOOP_LPCOUNT1
+#define PULPV2_HWLOOP_LPSTART(x) (PULPV2_HWLOOP_LPSTART0 + (x)*4)
+#define PULPV2_HWLOOP_LPEND(x)   (PULPV2_HWLOOP_LPEND0 + (x)*4)
+#define PULPV2_HWLOOP_LPCOUNT(x)  (PULPV2_HWLOOP_LPCOUNT0 + (x)*4)
+
+static inline iss_reg_t LB_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LB_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(1));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(1));
+    iss->lsu.stack_access_check(REG_IN(1), REG_GET(0) + REG_GET(1));
+    if (iss->lsu.load_signed_perf<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LH_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LH_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(1));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(1));
+    iss->lsu.stack_access_check(REG_IN(1), REG_GET(0) + REG_GET(1));
+    if (iss->lsu.load_signed_perf<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LW_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load<int32_t>(insn, REG_GET(0) + REG_GET(1), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LW_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(1));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(1));
+    iss->lsu.stack_access_check(REG_IN(1), REG_GET(0) + REG_GET(1));
+    if (iss->lsu.load_perf<uint32_t>(insn, REG_GET(0) + REG_GET(1), 4, REG_OUT(0)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LBU_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load<int8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LBU_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(1));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(1));
+    iss->lsu.stack_access_check(REG_IN(1), REG_GET(0) + REG_GET(1));
+    if (iss->lsu.load_perf<uint8_t>(insn, REG_GET(0) + REG_GET(1), 1, REG_OUT(0)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LHU_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load<int16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LHU_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(1));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(1));
+    iss->lsu.stack_access_check(REG_IN(1), REG_GET(0) + REG_GET(1));
+    if (iss->lsu.load_perf<uint16_t>(insn, REG_GET(0) + REG_GET(1), 2, REG_OUT(0)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LB_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LB_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    if (iss->lsu.load_signed_perf<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LH_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LH_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    if (iss->lsu.load_signed_perf<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LW_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load_signed<int32_t>(insn, REG_GET(0), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LW_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    if (iss->lsu.load_signed_perf<int32_t>(insn, REG_GET(0), 4, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LBU_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LBU_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.load_perf<uint8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LHU_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.load<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LHU_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.load_perf<uint16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SB_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SB_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.store_perf<uint8_t>(insn, REG_GET(0), 1, REG_IN(1)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SH_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SH_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.store_perf<uint16_t>(insn, REG_GET(0), 2, REG_IN(1)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SW_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SW_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.store_perf<uint32_t>(insn, REG_GET(0), 4, REG_IN(1)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, REG_GET(0) + SIM_GET(0));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LB_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load_signed<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LB_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(1));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load_signed_perf<int8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LH_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load_signed<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LH_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(1));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load_signed_perf<int16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LW_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load_signed<int32_t>(insn, REG_GET(0), 4, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LW_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(1));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load_signed_perf<int32_t>(insn, REG_GET(0), 4, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LBU_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load<uint8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LBU_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(1));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.load_perf<uint8_t>(insn, REG_GET(0), 1, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LHU_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    if (iss->lsu.load<uint16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t LHU_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(1));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(1);
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0));
+    if (iss->lsu.load_perf<uint16_t>(insn, REG_GET(0), 2, REG_OUT(0)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SB_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(2);
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SB_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(2));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(2);
+    iss->lsu.stack_access_check(REG_OUT(0), REG_GET(0));
+    if (iss->lsu.store_perf<uint8_t>(insn, REG_GET(0), 1, REG_IN(1)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SH_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(2);
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SH_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(2));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(2);
+    iss->lsu.stack_access_check(REG_OUT(0), REG_GET(0));
+    if (iss->lsu.store_perf<uint16_t>(insn, REG_GET(0), 2, REG_IN(1)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SW_RR_POSTINC_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss_reg_t new_val = REG_GET(0) + REG_GET(2);
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SW_RR_POSTINC_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    // Since input register is incremented, whole register becomes invalid if any bit is invalid
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_IN(0), REG_IN(2));
+
+    iss_reg_t new_val = REG_GET(0) + REG_GET(2);
+    iss->lsu.stack_access_check(REG_OUT(0), REG_GET(0));
+    if (iss->lsu.store_perf<uint32_t>(insn, REG_GET(0), 4, REG_IN(1)))
+    {
+        return pc;
+    }
+    IN_REG_SET(0, new_val);
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_avgu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, LIB_CALL2(lib_AVGU, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_slet_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, (int32_t)REG_GET(0) <= (int32_t)REG_GET(1));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_sletu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, REG_GET(0) <= REG_GET(1));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_min_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+
+    REG_SET(0, LIB_CALL2(lib_MINS, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_minu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+
+    REG_SET(0, LIB_CALL2(lib_MINU, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_max_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+
+    REG_SET(0, LIB_CALL2(lib_MAXS, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_maxu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+
+    REG_SET(0, LIB_CALL2(lib_MAXU, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_ror_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (!iss->regfile.memcheck_get_valid(REG_IN(1)))
+    {
+        // If register containing the rotation is invalid, this is making the whole output
+        // register invalid
+        iss->regfile.memcheck_set_valid(REG_OUT(0), false);
+    }
+    else
+    {
+        // Otherwise, handle the bits separately
+        iss->regfile.memcheck_set(REG_OUT(0),
+            LIB_CALL2(lib_ROR, iss->regfile.memcheck_get(REG_IN(0)), REG_GET(1)));
+    }
+
+    REG_SET(0, LIB_CALL2(lib_ROR, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_ff1_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, LIB_CALL1(lib_FF1, REG_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_fl1_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, LIB_CALL1(lib_FL1, REG_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_clb_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, LIB_CALL1(lib_CLB, REG_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_cnt_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, LIB_CALL1(lib_CNT, REG_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_exths_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_set(REG_OUT(0),
+        iss_get_signed_value(iss->regfile.memcheck_get(REG_IN(0)), 16));
+
+    REG_SET(0, iss_get_signed_value(REG_GET(0), 16));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_exthz_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_set(REG_OUT(0),
+        iss_get_field(iss->regfile.memcheck_get(REG_IN(0)), 0, 16) |
+        (((1 << (ISS_REG_WIDTH - 16)) - 1) << 16));
+
+    REG_SET(0, iss_get_field(REG_GET(0), 0, 16));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_extbs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_set(REG_OUT(0),
+        iss_get_signed_value(iss->regfile.memcheck_get(REG_IN(0)), 8));
+
+    REG_SET(0, iss_get_signed_value(REG_GET(0), 8));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_extbz_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_set(REG_OUT(0),
+        iss_get_field(iss->regfile.memcheck_get(REG_IN(0)), 0, 8) |
+        (((1 << (ISS_REG_WIDTH - 8)) - 1) << 8));
+
+    REG_SET(0, iss_get_field(REG_GET(0), 0, 8));
+    return iss_insn_next(iss, insn, pc);
+}
+
+/* Unified hwloop functions — PulpV2 names delegate to corev_ versions.
+ * PULPV2_HWLOOP_* are aliases of COREV_HWLOOP_* (same register layout),
+ * so the implementations are identical. */
+#ifndef CONFIG_GVSOC_ISS_SNITCH_PULP_V2
+#ifndef CONFIG_GVSOC_ISS_V2
+static inline iss_reg_t hwloop_check_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return corev_hwloop_check_exec(iss, insn, pc);
+}
+
+static inline void hwloop_set_start(Iss *iss, iss_insn_t *insn, int index, iss_reg_t start)
+{
+    corev_hwloop_set_start(iss, insn, index, start);
+}
+
+static inline void hwloop_set_end(Iss *iss, iss_insn_t *insn, int index, iss_reg_t end)
+{
+    corev_hwloop_set_end(iss, insn, index, end);
+}
+
+static inline void hwloop_set_count(Iss *iss, iss_insn_t *insn, int index, iss_reg_t count)
+{
+    corev_hwloop_set_count(iss, insn, index, count);
+}
+
+static inline void hwloop_set_all(Iss *iss, iss_insn_t *insn, int index, iss_reg_t start, iss_reg_t end, iss_reg_t count)
+{
+    corev_hwloop_set_all(iss, insn, index, start, end, count);
+}
+#endif
+
+// CV32E40P CoreV2 encodes the hwloop "immediate" as a word offset (x4) --
+// RTL cv32e40p_id_stage.sv:1366 `pc + (imm_iz_type << 2)` and
+// cv32e40p_hwloop_regs.sv:71,83 force 4-byte alignment. The legacy PulpV2
+// default was halfword (x2). Behavior-preserving for non-CV32E40P (macro=1).
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+#define COREV_HWLOOP_IMM_SHIFT 2
+#else
+#define COREV_HWLOOP_IMM_SHIFT 1
+#endif
+
+static inline iss_reg_t lp_starti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    hwloop_set_start(iss, insn, UIM_GET(0), pc + (UIM_GET(1) << COREV_HWLOOP_IMM_SHIFT));
+#endif
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t lp_endi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    hwloop_set_end(iss, insn, UIM_GET(0), pc + (UIM_GET(1) << COREV_HWLOOP_IMM_SHIFT));
+#endif
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t lp_count_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    iss->regfile.memcheck_branch_reg(REG_IN(0));
+
+    hwloop_set_count(iss, insn, UIM_GET(0), REG_GET(0));
+#endif
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t lp_counti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    hwloop_set_count(iss, insn, UIM_GET(0), UIM_GET(1));
+#endif
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t lp_setup_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    iss->regfile.memcheck_branch_reg(REG_IN(0));
+
+    int index = UIM_GET(0);
+    iss_reg_t count = REG_GET(0);
+    iss_reg_t start = pc + insn->size;
+    iss_reg_t end = pc + (UIM_GET(1) << COREV_HWLOOP_IMM_SHIFT);
+
+    hwloop_set_all(iss, insn, index, start, end, count);
+#endif
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t lp_setupi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    int index = UIM_GET(0);
+    iss_reg_t count = UIM_GET(1);
+    iss_reg_t start = pc + insn->size;
+    iss_reg_t end = pc + (UIM_GET(2) << COREV_HWLOOP_IMM_SHIFT);
+
+    hwloop_set_all(iss, insn, index, start, end, count);
+#endif
+
+    return iss_insn_next(iss, insn, pc);
+}
+#endif
+
+static inline iss_reg_t p_abs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+
+    REG_SET(0, LIB_CALL1(lib_ABS, REG_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SB_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.store<uint8_t>(insn, REG_GET(0) + REG_GET(2), 1, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SB_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(2));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(2));
+    iss->lsu.stack_access_check(REG_IN(2), REG_GET(0) + REG_GET(2));
+    if (iss->lsu.store_perf<uint8_t>(insn, REG_GET(0) + REG_GET(2), 1, REG_IN(1)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SH_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.store<uint16_t>(insn, REG_GET(0) + REG_GET(2), 2, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SH_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(2));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(2));
+    iss->lsu.stack_access_check(REG_IN(2), REG_GET(0) + REG_GET(2));
+    if (iss->lsu.store_perf<uint16_t>(insn, REG_GET(0) + REG_GET(2), 2, REG_IN(1)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SW_RR_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    if (iss->lsu.store<uint32_t>(insn, REG_GET(0) + REG_GET(2), 4, REG_IN(1)))
+    {
+        // This returns true if the core didn't manage to do the access and is stalled.
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t SW_RR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    // If address register is not valid, we are accessing random location, trigger
+    // a memcheck fail
+    iss->regfile.memcheck_access_reg(REG_IN(0));
+    iss->regfile.memcheck_access_reg(REG_IN(2));
+
+    iss->lsu.stack_access_check(REG_IN(0), REG_GET(0) + REG_GET(2));
+    iss->lsu.stack_access_check(REG_IN(2), REG_GET(0) + REG_GET(2));
+    if (iss->lsu.store_perf<uint32_t>(insn, REG_GET(0) + REG_GET(2), 4, REG_IN(1)))
+    {
+        return pc;
+    }
+    return iss_insn_next(iss, insn, pc);
+}
+
+
+static inline iss_reg_t p_elw_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+#ifndef CONFIG_GVSOC_ISS_V2
+    iss->regfile.memcheck_branch_reg(REG_IN(0));
+
+    iss_handle_elw(iss, insn, pc, REG_GET(0) + SIM_GET(0), 4, REG_OUT(0));
+#endif
+    return iss_insn_next(iss, insn, pc);
+}
+
+#define PV_OP_RS_EXEC(insn_name, lib_name)                                                         \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                  \
+    {                                                                                              \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_int16_t_to_int32_t, REG_GET(0), REG_GET(1)));    \
+        return iss_insn_next(iss, insn, pc);                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static inline iss_reg_t pv_##insn_name##_sc_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)               \
+    {                                                                                              \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int16_t_to_int32_t, REG_GET(0), REG_GET(1))); \
+        return iss_insn_next(iss, insn, pc);                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static inline iss_reg_t pv_##insn_name##_sci_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
+    {                                                                                              \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int16_t_to_int32_t, REG_GET(0), SIM_GET(0))); \
+        return iss_insn_next(iss, insn, pc);                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                  \
+    {                                                                                              \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_int8_t_to_int32_t, REG_GET(0), REG_GET(1)));     \
+        return iss_insn_next(iss, insn, pc);                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static inline iss_reg_t pv_##insn_name##_sc_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)               \
+    {                                                                                              \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int8_t_to_int32_t, REG_GET(0), REG_GET(1)));  \
+        return iss_insn_next(iss, insn, pc);                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static inline iss_reg_t pv_##insn_name##_sci_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
+    {                                                                                              \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_int8_t_to_int32_t, REG_GET(0), SIM_GET(0)));  \
+        return iss_insn_next(iss, insn, pc);                                                                         \
+    }
+
+#define PV_OP_RU_EXEC(insn_name, lib_name)                                                           \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                    \
+    {                                                                                                \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_uint16_t_to_uint32_t, REG_GET(0), REG_GET(1)));    \
+        return iss_insn_next(iss, insn, pc);                                                                           \
+    }                                                                                                \
+                                                                                                     \
+    static inline iss_reg_t pv_##insn_name##_sc_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                 \
+    {                                                                                                \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint16_t_to_uint32_t, REG_GET(0), REG_GET(1))); \
+        return iss_insn_next(iss, insn, pc);                                                                           \
+    }                                                                                                \
+                                                                                                     \
+    static inline iss_reg_t pv_##insn_name##_sci_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                \
+    {                                                                                                \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint16_t_to_uint32_t, REG_GET(0), UIM_GET(0))); \
+        return iss_insn_next(iss, insn, pc);                                                                           \
+    }                                                                                                \
+                                                                                                     \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                    \
+    {                                                                                                \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_uint8_t_to_uint32_t, REG_GET(0), REG_GET(1)));     \
+        return iss_insn_next(iss, insn, pc);                                                                           \
+    }                                                                                                \
+                                                                                                     \
+    static inline iss_reg_t pv_##insn_name##_sc_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                 \
+    {                                                                                                \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint8_t_to_uint32_t, REG_GET(0), REG_GET(1)));  \
+        return iss_insn_next(iss, insn, pc);                                                                           \
+    }                                                                                                \
+                                                                                                     \
+    static inline iss_reg_t pv_##insn_name##_sci_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)                \
+    {                                                                                                \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_uint8_t_to_uint32_t, REG_GET(0), UIM_GET(0)));  \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        return iss_insn_next(iss, insn, pc);                                                                           \
+    }
+
+#define PV_OP_RS_EXEC2(insn_name, lib_name)                                           \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_16, REG_GET(0), REG_GET(1)));       \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1)));    \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), SIM_GET(0)));    \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_8, REG_GET(0), REG_GET(1)));        \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1)));     \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), SIM_GET(0)));     \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }
+
+#define PV_OP_RU_EXEC2(insn_name, lib_name)                                           \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_16, REG_GET(0), REG_GET(1)));       \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1)));    \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_16, REG_GET(0), UIM_GET(0)));    \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)     \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_8, REG_GET(0), REG_GET(1)));        \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)  \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1)));     \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }                                                                                 \
+                                                                                      \
+    static inline iss_reg_t pv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc) \
+    {                                                                                 \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL2(lib_VEC_##lib_name##_SC_8, REG_GET(0), UIM_GET(0)));     \
+        return iss_insn_next(iss, insn, pc);                                                            \
+    }
+
+#define PV_OP_RRS_EXEC2(insn_name, lib_name)                                                   \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_16, REG_GET(2), REG_GET(0), REG_GET(1)));    \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(2), REG_GET(0), REG_GET(1))); \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1), SIM_GET(0))); \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_8, REG_GET(2), REG_GET(0), REG_GET(1)));     \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(2), REG_GET(0), REG_GET(1)));  \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1), SIM_GET(0)));  \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }
+
+#define PV_OP_RRU_EXEC2(insn_name, lib_name)                                                   \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_16, REG_GET(2), REG_GET(0), REG_GET(1)));    \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_h_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(2), REG_GET(0), REG_GET(1))); \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_16, REG_GET(0), REG_GET(1), UIM_GET(0))); \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)              \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_8, REG_GET(2), REG_GET(0), REG_GET(1)));     \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_b_sc_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)           \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(2), REG_GET(0), REG_GET(1)));  \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }                                                                                          \
+                                                                                               \
+    static inline iss_reg_t pv_##insn_name##_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)          \
+    {                                                                                          \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));                                        \
+        REG_SET(0, LIB_CALL3(lib_VEC_##lib_name##_SC_8, REG_GET(0), REG_GET(1), UIM_GET(0)));  \
+        return iss_insn_next(iss, insn, pc);                                                                     \
+    }
+
+#define PV_OP1_RS_EXEC(insn_name, lib_name)                                         \
+    static inline iss_reg_t pv_##insn_name##_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)   \
+    {                                                                               \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL1(lib_VEC_##lib_name##_int16_t_to_int32_t, REG_GET(0))); \
+        return iss_insn_next(iss, insn, pc);                                                          \
+    }                                                                               \
+                                                                                    \
+    static inline iss_reg_t pv_##insn_name##_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)   \
+    {                                                                               \
+        iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));                                        \
+        REG_SET(0, LIB_CALL1(lib_VEC_##lib_name##_int8_t_to_int32_t, REG_GET(0)));  \
+        return iss_insn_next(iss, insn, pc);                                                          \
+    }
+
+PV_OP_RS_EXEC(add, ADD)
+
+PV_OP_RS_EXEC(sub, SUB)
+
+PV_OP_RS_EXEC(avg, AVG)
+
+PV_OP_RU_EXEC(avgu, AVGU)
+
+PV_OP_RS_EXEC(min, MIN)
+
+PV_OP_RU_EXEC(minu, MINU)
+
+PV_OP_RS_EXEC(max, MAX)
+
+PV_OP_RU_EXEC(maxu, MAXU)
+
+PV_OP_RU_EXEC(srl, SRL)
+
+PV_OP_RS_EXEC(sra, SRA)
+
+PV_OP_RU_EXEC(sll, SLL)
+
+PV_OP_RS_EXEC(or, OR)
+
+PV_OP_RS_EXEC(xor, XOR)
+
+PV_OP_RS_EXEC(and, AND)
+
+PV_OP1_RS_EXEC(abs, ABS)
+
+static inline iss_reg_t pv_extract_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_EXT_16, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_extract_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_EXT_8, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_extractu_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_EXTU_16, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_extractu_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_EXTU_8, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_insert_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_VEC_INS_16, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_insert_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_VEC_INS_8, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+PV_OP_RS_EXEC2(dotsp, DOTSP)
+
+PV_OP_RU_EXEC2(dotup, DOTUP)
+
+PV_OP_RS_EXEC2(dotusp, DOTUSP)
+
+PV_OP_RRS_EXEC2(sdotsp, SDOTSP)
+
+PV_OP_RRU_EXEC2(sdotup, SDOTUP)
+
+PV_OP_RRS_EXEC2(sdotusp, SDOTUSP)
+
+static inline iss_reg_t pv_shuffle_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLE_16, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shuffle_h_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLE_SCI_16, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shuffle_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLE_8, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shufflei0_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI0_SCI_8, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shufflei1_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI1_SCI_8, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shufflei2_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI2_SCI_8, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shufflei3_b_sci_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    REG_SET(0, LIB_CALL2(lib_VEC_SHUFFLEI3_SCI_8, REG_GET(0), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shuffle2_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_VEC_SHUFFLE2_16, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_shuffle2_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_VEC_SHUFFLE2_8, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_pack_h_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_VEC_PACK_SC_16, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_packhi_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_VEC_PACKHI_SC_8, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t pv_packlo_b_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_VEC_PACKLO_SC_8, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+PV_OP_RS_EXEC(cmpeq, CMPEQ)
+
+PV_OP_RS_EXEC(cmpne, CMPNE)
+
+PV_OP_RS_EXEC(cmpgt, CMPGT)
+
+PV_OP_RS_EXEC(cmpge, CMPGE)
+
+PV_OP_RS_EXEC(cmplt, CMPLT)
+
+PV_OP_RS_EXEC(cmple, CMPLE)
+
+PV_OP_RU_EXEC(cmpgtu, CMPGTU)
+
+PV_OP_RU_EXEC(cmpgeu, CMPGEU)
+
+PV_OP_RU_EXEC(cmpltu, CMPLTU)
+
+PV_OP_RU_EXEC(cmpleu, CMPLEU)
+
+static inline iss_reg_t p_bneimm_exec_common(Iss *iss, iss_insn_t *insn, iss_reg_t pc, int perf)
+{
+    iss->regfile.memcheck_branch_reg(REG_IN(0));
+
+    if ((int32_t)REG_GET(0) != SIM_GET(1))
+    {
+#if defined(CONFIG_GVSOC_ISS_V2)
+        iss->timing.event_taken_branch_account();
+#else
+        iss->timing.stall_taken_branch_account();
+#endif
+        return pc + SIM_GET(0);
+    }
+    else
+    {
+        if (perf)
+        {
+            iss->timing.event_branch_account();
+        }
+        return iss_insn_next(iss, insn, pc);
+    }
+}
+
+static inline iss_reg_t p_bneimm_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return p_bneimm_exec_common(iss, insn, pc, 0);
+}
+
+static inline iss_reg_t p_bneimm_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return p_bneimm_exec_common(iss, insn, pc, 1);
+}
+
+static inline iss_reg_t p_beqimm_exec_common(Iss *iss, iss_insn_t *insn, iss_reg_t pc, int perf)
+{
+    iss->regfile.memcheck_branch_reg(REG_IN(0));
+
+    if ((int32_t)REG_GET(0) == SIM_GET(1))
+    {
+#if defined(CONFIG_GVSOC_ISS_V2)
+        iss->timing.event_taken_branch_account();
+#else
+        iss->timing.stall_taken_branch_account();
+#endif
+        return pc + SIM_GET(0);
+    }
+    else
+    {
+        if (perf)
+        {
+            iss->timing.event_branch_account();
+        }
+        return iss_insn_next(iss, insn, pc);
+    }
+}
+
+static inline iss_reg_t p_beqimm_exec_fast(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return p_beqimm_exec_common(iss, insn, pc, 0);
+}
+
+static inline iss_reg_t p_beqimm_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    return p_beqimm_exec_common(iss, insn, pc, 1);
+}
+
+static inline iss_reg_t p_mac_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_MAC, REG_GET(2), REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_msu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_MSU, REG_GET(2), REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mul_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_MULS, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_muls_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_MUL_SL_SL, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulhhs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_MUL_SH_SH, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_SL_SL_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulhhsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_SH_SH_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulsNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_SL_SL_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulhhsNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_SH_SH_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_MUL_ZL_ZL, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulhhu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL2(lib_MUL_ZH_ZH, REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_muluN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_ZL_ZL_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulhhuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_ZH_ZH_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_muluNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_ZL_ZL_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_mulhhuNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_MUL_ZH_ZH_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_macs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_MAC_SL_SL, REG_GET(2), REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_machhs_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_MAC_SH_SH, REG_GET(2), REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_macsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_SL_SL_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_machhsN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_SH_SH_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_macsNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_SL_SL_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_machhsNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_SH_SH_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_macu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_MAC_ZL_ZL, REG_GET(2), REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_machhu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_MAC_ZH_ZH, REG_GET(2), REG_GET(0), REG_GET(1)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_macuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_ZL_ZL_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_machhuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_ZH_ZH_NR, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_macuNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_ZL_ZL_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_machhuNR_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL4(lib_MAC_ZH_ZH_NR_R, REG_GET(2), REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_addNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_ADD_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_adduNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_ADD_NRU, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_addRNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_ADD_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_adduRNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_ADD_NR_RU, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_SUB_NR, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subuNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_SUB_NRU, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subRNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_SUB_NR_R, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subuRNi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    REG_SET(0, LIB_CALL3(lib_SUB_NR_RU, REG_GET(0), REG_GET(1), UIM_GET(0)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_addN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_ADD_NR, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_adduN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_ADD_NRU, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_addRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_ADD_NR_R, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_adduRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_ADD_NR_RU, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_SUB_NR, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subuN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_SUB_NRU, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_SUB_NR_R, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_subuRN_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(2));
+    REG_SET(0, LIB_CALL3(lib_SUB_NR_RU, REG_GET(0), REG_GET(1), REG_GET(2)));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_clipi_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    int low = (int)-(1 << MAX((int)UIM_GET(0) - 1, 0));
+    int high = (1 << MAX((int)UIM_GET(0) - 1, 0)) - 1;
+    REG_SET(0, LIB_CALL3(lib_CLIP, REG_GET(0), low, high));
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_clipui_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    int high = (1 << MAX((int)UIM_GET(0) - 1, 0)) - 1;
+    REG_SET(0, LIB_CALL2(lib_CLIPU, REG_GET(0), high));
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_clip_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    int low = -REG_GET(1) - 1;
+    int high = REG_GET(1);
+    REG_SET(0, LIB_CALL3(lib_CLIP, REG_GET(0), low, high));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_clipu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    int high = REG_GET(1);
+    REG_SET(0, LIB_CALL2(lib_CLIPU, REG_GET(0), high));
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_bclri_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    int width = UIM_GET(0) + 1;
+    int shift = UIM_GET(1);
+    REG_SET(0, LIB_CALL2(lib_BCLR, REG_GET(0), ((1ULL << width) - 1) << shift));
+
+    iss->regfile.memcheck_set(REG_OUT(0),
+        iss->regfile.memcheck_get(REG_IN(0)) | ((1ULL << width) - 1) << shift);
+
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_bclr_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    int width = ((REG_GET(1) >> 5) & 0x1f) + 1;
+    int shift = REG_GET(1) & 0x1f;
+    REG_SET(0, LIB_CALL2(lib_BCLR, REG_GET(0), ((1ULL << width) - 1) << shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_extracti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    int width = UIM_GET(0) + 1;
+    int shift = UIM_GET(1);
+    REG_SET(0, LIB_CALL3(lib_BEXTRACT, REG_GET(0), width, shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_extractui_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    int width = UIM_GET(0) + 1;
+    int shift = UIM_GET(1);
+    REG_SET(0, LIB_CALL3(lib_BEXTRACTU, REG_GET(0), ((1ULL << width) - 1) << shift, shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_extract_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    int width = ((REG_GET(1) >> 5) & 0x1f) + 1;
+    int shift = REG_GET(1) & 0x1f;
+    REG_SET(0, LIB_CALL3(lib_BEXTRACT, REG_GET(0), width, shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_extractu_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    int width = ((REG_GET(1) >> 5) & 0x1f) + 1;
+    int shift = REG_GET(1) & 0x1f;
+    REG_SET(0, LIB_CALL3(lib_BEXTRACTU, REG_GET(0), ((1ULL << width) - 1) << shift, shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_inserti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    int width = UIM_GET(0) + 1;
+    int shift = UIM_GET(1);
+    REG_SET(0, LIB_CALL4(lib_BINSERT, REG_GET(0), REG_GET(1), ((1ULL << width) - 1) << shift, shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_insert_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    int width = ((REG_GET(2) >> 5) & 0x1F) + 1;
+    int shift = REG_GET(2) & 0x1F;
+    REG_SET(0, LIB_CALL4(lib_BINSERT, REG_GET(0), REG_GET(1), ((1ULL << width) - 1) << shift, shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_bseti_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    int width = UIM_GET(0) + 1;
+    int shift = UIM_GET(1);
+    REG_SET(0, LIB_CALL2(lib_BSET, REG_GET(0), ((1ULL << (width)) - 1) << shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
+static inline iss_reg_t p_bset_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
+{
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(0));
+    iss->regfile.memcheck_merge(REG_OUT(0), REG_IN(1));
+    int width = ((REG_GET(1) >> 5) & 0x1f) + 1;
+    int shift = REG_GET(1) & 0x1f;
+    REG_SET(0, LIB_CALL2(lib_BSET, REG_GET(0), ((1ULL << (width)) - 1) << shift));
+    return iss_insn_next(iss, insn, pc);
+}
+
 
 #endif

--- a/models/cpu/iss/include/isa/rv32i.hpp
+++ b/models/cpu/iss/include/isa/rv32i.hpp
@@ -782,6 +782,14 @@ static inline iss_reg_t ebreak_exec(Iss *iss, iss_insn_t *insn, iss_reg_t pc)
     {
         return iss->irq.debug_handler;
     }
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // dcsr.ebreakm=1 in M-mode: enter debug (RISC-V Debug Spec §3.1.2).
+    else if (iss->csr.ebreak_m_mode_enters_debug())
+    {
+        iss->dbgunit.set_halt_mode(true, HALT_CAUSE_EBREAK);
+        return pc;
+    }
+#endif
     else
     {
         iss->exception.raise(pc, ISS_EXCEPT_BREAKPOINT);

--- a/models/cpu/iss/isa_gen/isa_cv32e40pv2.py
+++ b/models/cpu/iss/isa_gen/isa_cv32e40pv2.py
@@ -1,0 +1,206 @@
+#
+# Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+#                    University of Bologna
+# Copyright (C) 2026 Fondazione Chips-it
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+#
+
+from cpu.iss.isa_gen.isa_gen import *
+from cpu.iss.isa_gen.isa_riscv_gen import *
+from cpu.iss.isa_gen.isa_corev import Format_SB2, Format_LPOST, Format_LRPOST, Format_LR, Format_SPOST, Format_SRPOST, Format_SR, Format_HL0, Format_HL1, Format_RRRR, Format_RRRR2, Format_RRRU2, Format_RRRRU, Format_R1, Format_I1U, Format_I4U, Format_I5U, Format_I5U2, Format_BITREV
+
+# CORE-V v2 uses standard RISC-V custom opcodes:
+# Custom-0: 0x0B (0001011) - Branching & Load Immediate Post-Inc
+# Custom-1: 0x2B (0101011) - Store Immediate Post-Inc & Register Load/Store
+# Custom-2: 0x5B (1011011) - Multiplication / MAC / HWLoop
+
+class CoreV2(IsaSubset):
+
+    def __init__(self):
+        instrs = []
+
+        # --- Custom-0 (0x0B): Branching and Load Post-Increment ---
+        # Note: names must match C++ handler names (case sensitive)
+        instrs += [
+            Instr('p.beqimm', Format_SB2, '------- ----- ----- 110 ----- 0001011', fast_handler=True, decode='bxx_decode', L='cv.beqimm'),
+            Instr('p.bneimm', Format_SB2, '------- ----- ----- 111 ----- 0001011', fast_handler=True, decode='bxx_decode', L='cv.bneimm'),
+            
+            Instr('LB_POSTINC',    Format_LPOST, '------- ----- ----- 000 ----- 0001011', L='cv.lb' , fast_handler=True, tags=["load"]),
+            Instr('LBU_POSTINC',   Format_LPOST, '------- ----- ----- 100 ----- 0001011', L='cv.lbu', fast_handler=True, tags=["load"]),
+            Instr('LH_POSTINC',    Format_LPOST, '------- ----- ----- 001 ----- 0001011', L='cv.lh' , fast_handler=True, tags=["load"]),
+            Instr('LHU_POSTINC',   Format_LPOST, '------- ----- ----- 101 ----- 0001011', L='cv.lhu', fast_handler=True, tags=["load"]),
+            Instr('LW_POSTINC',    Format_LPOST, '------- ----- ----- 010 ----- 0001011', L='cv.lw' , fast_handler=True, tags=["load"]),
+            
+            Instr('p.elw',         Format_L,     '------- ----- ----- 011 ----- 0001011', L='cv.elw', tags=["load"]),
+        ]
+
+        # --- Custom-1 (0x2B): Store Post-Increment and Register Indexed Load/Store ---
+        instrs += [
+            Instr('SB_POSTINC',    Format_SPOST, '------- ----- ----- 000 ----- 0101011', L='cv.sb' , fast_handler=True),
+            Instr('SH_POSTINC',    Format_SPOST, '------- ----- ----- 001 ----- 0101011', L='cv.sh' , fast_handler=True),
+            Instr('SW_POSTINC',    Format_SPOST, '------- ----- ----- 010 ----- 0101011', L='cv.sw' , fast_handler=True),
+
+            Instr('LB_RR_POSTINC',   Format_LRPOST,  '0000000 ----- ----- 011 ----- 0101011', L='cv.lb' , fast_handler=True, tags=["load"]),
+            Instr('LBU_RR_POSTINC',  Format_LRPOST,  '0001000 ----- ----- 011 ----- 0101011', L='cv.lbu', fast_handler=True, tags=["load"]),
+            Instr('LH_RR_POSTINC',   Format_LRPOST,  '0000001 ----- ----- 011 ----- 0101011', L='cv.lh' , fast_handler=True, tags=["load"]),
+            Instr('LHU_RR_POSTINC',  Format_LRPOST,  '0001001 ----- ----- 011 ----- 0101011', L='cv.lhu', fast_handler=True, tags=["load"]),
+            Instr('LW_RR_POSTINC',   Format_LRPOST,  '0000010 ----- ----- 011 ----- 0101011', L='cv.lw' , fast_handler=True, tags=["load"]),
+
+            Instr('LB_RR',    Format_LR, '0000100 ----- ----- 011 ----- 0101011', L='cv.lb' , fast_handler=True, tags=["load"]),
+            Instr('LBU_RR',   Format_LR, '0001100 ----- ----- 011 ----- 0101011', L='cv.lbu', fast_handler=True, tags=["load"]),
+            Instr('LH_RR',    Format_LR, '0000101 ----- ----- 011 ----- 0101011', L='cv.lh' , fast_handler=True, tags=["load"]),
+            Instr('LHU_RR',   Format_LR, '0001101 ----- ----- 011 ----- 0101011', L='cv.lhu', fast_handler=True, tags=["load"]),
+            Instr('LW_RR',    Format_LR, '0000110 ----- ----- 011 ----- 0101011', L='cv.lw' , fast_handler=True, tags=["load"]),
+
+            Instr('SB_RR_POSTINC',   Format_SRPOST, '0010000 ----- ----- 011 ----- 0101011',  L='cv.sb' , fast_handler=True),
+            Instr('SH_RR_POSTINC',   Format_SRPOST, '0010001 ----- ----- 011 ----- 0101011',  L='cv.sh' , fast_handler=True),
+            Instr('SW_RR_POSTINC',   Format_SRPOST, '0010010 ----- ----- 011 ----- 0101011',  L='cv.sw' , fast_handler=True),
+
+            Instr('SB_RR',    Format_SR, '0010100 ----- ----- 011 ----- 0101011', L='cv.sb', fast_handler=True),
+            Instr('SH_RR',    Format_SR, '0010101 ----- ----- 011 ----- 0101011', L='cv.sh', fast_handler=True),
+            Instr('SW_RR',    Format_SR, '0010110 ----- ----- 011 ----- 0101011', L='cv.sw', fast_handler=True),
+        ]
+
+        # --- Custom-1 Plane A (0x2B, funct3=011): General ALU Operations ---
+        instrs += [
+            Instr('p.ror',    Format_R,  '0100000 ----- ----- 011 ----- 0101011', L='cv.ror'),
+            Instr('p.ff1',    Format_R1, '0100001 00000 ----- 011 ----- 0101011', L='cv.ff1'),
+            Instr('p.fl1',    Format_R1, '0100010 00000 ----- 011 ----- 0101011', L='cv.fl1'),
+            Instr('p.clb',    Format_R1, '0100011 00000 ----- 011 ----- 0101011', L='cv.clb'),
+            Instr('p.cnt',    Format_R1, '0100100 00000 ----- 011 ----- 0101011', L='cv.cnt'),
+            Instr('p.abs',    Format_R1, '0101000 00000 ----- 011 ----- 0101011', L='cv.abs'),
+            Instr('p.slet',   Format_R,  '0101001 ----- ----- 011 ----- 0101011', L='cv.slet'),
+            Instr('p.sletu',  Format_R,  '0101010 ----- ----- 011 ----- 0101011', L='cv.sletu'),
+            Instr('p.min',    Format_R,  '0101011 ----- ----- 011 ----- 0101011', L='cv.min'),
+            Instr('p.minu',   Format_R,  '0101100 ----- ----- 011 ----- 0101011', L='cv.minu'),
+            Instr('p.max',    Format_R,  '0101101 ----- ----- 011 ----- 0101011', L='cv.max'),
+            Instr('p.maxu',   Format_R,  '0101110 ----- ----- 011 ----- 0101011', L='cv.maxu'),
+            Instr('p.exths',  Format_R1, '0110000 00000 ----- 011 ----- 0101011', L='cv.exths'),
+            Instr('p.exthz',  Format_R1, '0110001 00000 ----- 011 ----- 0101011', L='cv.exthz'),
+            Instr('p.extbs',  Format_R1, '0110010 00000 ----- 011 ----- 0101011', L='cv.extbs'),
+            Instr('p.extbz',  Format_R1, '0110011 00000 ----- 011 ----- 0101011', L='cv.extbz'),
+            Instr('p.clipi',  Format_I1U, '0111000 ----- ----- 011 ----- 0101011', L='cv.clip'),
+            Instr('p.clipui', Format_I1U, '0111001 ----- ----- 011 ----- 0101011', L='cv.clipu'),
+            Instr('cv.clipr',  Format_R,  '0111010 ----- ----- 011 ----- 0101011'),
+            Instr('cv.clipur', Format_R,  '0111011 ----- ----- 011 ----- 0101011'),
+        ]
+
+        # --- Custom-1 Plane A (0x2B, funct3=011): Register-Register Add/Sub with Normalization ---
+        # funct7[31:29]=100, funct7[27]=sub, funct7[26]=round, funct7[25]=unsigned
+        # Shift amount from register (Format_RRRR2), handlers p_addN_exec etc.
+        instrs += [
+            Instr('p.addN',    Format_RRRR2, '1000000 ----- ----- 011 ----- 0101011', L='cv.addN'),
+            Instr('p.adduN',   Format_RRRR2, '1000001 ----- ----- 011 ----- 0101011', L='cv.adduN'),
+            Instr('p.addRN',   Format_RRRR2, '1000010 ----- ----- 011 ----- 0101011', L='cv.addRN'),
+            Instr('p.adduRN',  Format_RRRR2, '1000011 ----- ----- 011 ----- 0101011', L='cv.adduRN'),
+            Instr('p.subN',    Format_RRRR2, '1000100 ----- ----- 011 ----- 0101011', L='cv.subN'),
+            Instr('p.subuN',   Format_RRRR2, '1000101 ----- ----- 011 ----- 0101011', L='cv.subuN'),
+            Instr('p.subRN',   Format_RRRR2, '1000110 ----- ----- 011 ----- 0101011', L='cv.subRN'),
+            Instr('p.subuRN',  Format_RRRR2, '1000111 ----- ----- 011 ----- 0101011', L='cv.subuRN'),
+        ]
+
+        # --- Custom-1 Plane A (0x2B, funct3=011): Register Bit-Manipulation ---
+        # funct7[31:27]=00110 (7'b0011xxx), instr[27:25] selects variant
+        instrs += [
+            Instr('p.extract',  Format_R,    '0011000 ----- ----- 011 ----- 0101011', L='cv.extractr'),
+            Instr('p.extractu', Format_R,    '0011001 ----- ----- 011 ----- 0101011', L='cv.extractur'),
+            Instr('p.insert',   Format_I5U2, '0011010 ----- ----- 011 ----- 0101011', L='cv.insertr'),
+            Instr('p.bclr',     Format_R,    '0011100 ----- ----- 011 ----- 0101011', L='cv.bclrr'),
+            Instr('p.bset',     Format_R,    '0011101 ----- ----- 011 ----- 0101011', L='cv.bsetr'),
+        ]
+
+        # --- Custom-2 (0x5B): Bit-Manipulation, Add/Sub Norm, Multiply, MAC ---
+        # bits[14:13]=00: Bit manipulation (immediate)
+        # Selector: {bits[31:30], bit[12]}
+        instrs += [
+            Instr('p.extracti',  Format_I4U,    '00----- ----- ----- 000 ----- 1011011', L='cv.extract'),
+            Instr('p.extractui', Format_I4U,    '01----- ----- ----- 000 ----- 1011011', L='cv.extractu'),
+            Instr('p.inserti',   Format_I5U,    '10----- ----- ----- 000 ----- 1011011', L='cv.insert'),
+            Instr('p.bclri',     Format_I4U,    '00----- ----- ----- 001 ----- 1011011', L='cv.bclr'),
+            Instr('p.bseti',     Format_I4U,    '01----- ----- ----- 001 ----- 1011011', L='cv.bset'),
+            Instr('p.bitrev',    Format_BITREV, '11----- ----- ----- 001 ----- 1011011', L='cv.bitrev'),
+        ]
+
+        # --- Custom-2 (0x5B): Add/Sub Norm, Multiply, MAC ---
+        # Using 'p.' prefix to use handlers from pulp_v2.hpp
+        # v2 encoding: opcode=0x5B, bits[31:30] select variant, funct3 selects family:
+        #   funct3=010: addN variants    funct3=011: subN variants
+        #   funct3=100: mulsN variants   funct3=101: muluN variants
+        #   funct3=110: macsN variants   funct3=111: macuN variants
+        # bits[31:30]: 00=base, 01=hh(MAC/MUL)/unsigned(ADD/SUB), 10=round, 11=hh+round/unsigned+round
+
+        # Add/Sub with Normalization (funct3=010 add, 011 sub)
+        instrs += [
+            Instr('p.addNi',         Format_RRRU2,'00----- ----- ----- 010 ----- 1011011', L='cv.addN'),
+            Instr('p.adduNi',        Format_RRRU2,'01----- ----- ----- 010 ----- 1011011', L='cv.adduN'),
+            Instr('p.addRNi',        Format_RRRU2,'10----- ----- ----- 010 ----- 1011011', L='cv.addRN'),
+            Instr('p.adduRNi',       Format_RRRU2,'11----- ----- ----- 010 ----- 1011011', L='cv.adduRN'),
+            Instr('p.subNi',         Format_RRRU2,'00----- ----- ----- 011 ----- 1011011', L='cv.subN'),
+            Instr('p.subuNi',        Format_RRRU2,'01----- ----- ----- 011 ----- 1011011', L='cv.subuN'),
+            Instr('p.subRNi',        Format_RRRU2,'10----- ----- ----- 011 ----- 1011011', L='cv.subRN'),
+            Instr('p.subuRNi',       Format_RRRU2,'11----- ----- ----- 011 ----- 1011011', L='cv.subuRN'),
+        ]
+
+        # MUL operations (funct3=100 signed, 101 unsigned)
+        instrs += [
+            Instr('p.mulsN',         Format_RRRRU,'00----- ----- ----- 100 ----- 1011011', L='cv.mulsN'),
+            Instr('p.mulhhsN',       Format_RRRRU,'01----- ----- ----- 100 ----- 1011011', L='cv.mulhhsN'),
+            Instr('p.mulsNR',        Format_RRRRU,'10----- ----- ----- 100 ----- 1011011', L='cv.mulsRN'),
+            Instr('p.mulhhsNR',      Format_RRRRU,'11----- ----- ----- 100 ----- 1011011', L='cv.mulhhsRN'),
+            Instr('p.muluN',         Format_RRRRU,'00----- ----- ----- 101 ----- 1011011', L='cv.muluN'),
+            Instr('p.mulhhuN',       Format_RRRRU,'01----- ----- ----- 101 ----- 1011011', L='cv.mulhhuN'),
+            Instr('p.muluNR',        Format_RRRRU,'10----- ----- ----- 101 ----- 1011011', L='cv.muluRN'),
+            Instr('p.mulhhuNR',      Format_RRRRU,'11----- ----- ----- 101 ----- 1011011', L='cv.mulhhuRN'),
+        ]
+
+        # MAC operations (funct3=110 signed, 111 unsigned)
+        instrs += [
+            Instr('p.macsN',         Format_RRRRU,'00----- ----- ----- 110 ----- 1011011', L='cv.macsN'),
+            Instr('p.machhsN',       Format_RRRRU,'01----- ----- ----- 110 ----- 1011011', L='cv.machhsN'),
+            Instr('p.macsNR',        Format_RRRRU,'10----- ----- ----- 110 ----- 1011011', L='cv.macsRN'),
+            Instr('p.machhsNR',      Format_RRRRU,'11----- ----- ----- 110 ----- 1011011', L='cv.machhsRN'),
+            Instr('p.macuN',         Format_RRRRU,'00----- ----- ----- 111 ----- 1011011', L='cv.macuN'),
+            Instr('p.machhuN',       Format_RRRRU,'01----- ----- ----- 111 ----- 1011011', L='cv.machhuN'),
+            Instr('p.macuNR',        Format_RRRRU,'10----- ----- ----- 111 ----- 1011011', L='cv.macuRN'),
+            Instr('p.machhuNR',      Format_RRRRU,'11----- ----- ----- 111 ----- 1011011', L='cv.machhuRN'),
+        ]
+
+        # HWLoops — OPCODE_CUSTOM_1 = 0x2B, funct3=100 (Plane B)
+        # RTL: cv32e40p_decoder.sv lines 1935-2008, instr[11:8] (rd[4:1]) selects instruction
+        # instr[7] (rd[0]) = loop number (0 or 1)
+        instrs += [
+            Instr('lp.starti',Format_HL0,'------- ----- 00000 100 0000- 0101011', L='cv.starti'),
+            Instr('lp.start', Format_HL0,'0000000 00000 ----- 100 0001- 0101011', L='cv.start'),
+            Instr('lp.endi',  Format_HL0,'------- ----- 00000 100 0010- 0101011', L='cv.endi'),
+            Instr('lp.end',   Format_HL0,'0000000 00000 ----- 100 0011- 0101011', L='cv.end'),
+            Instr('lp.counti',Format_HL0,'------- ----- 00000 100 0100- 0101011', L='cv.counti'),
+            Instr('lp.count', Format_HL0,'0000000 00000 ----- 100 0101- 0101011', L='cv.count'),
+            Instr('lp.setupi',Format_HL1,'------- ----- ----- 100 0110- 0101011', L='cv.setupi'),
+            Instr('lp.setup', Format_HL0,'------- ----- ----- 100 0111- 0101011', L='cv.setup'),
+        ]
+
+        # mac/msu using PULP handlers
+        # Encoding from cv32e40p_decoder.sv line 1907 and xcvmac1p0 toolchain:
+        # cv.mac: custom-1 (0x2B), funct3=011, funct7=1001000
+        # cv.msu: custom-1 (0x2B), funct3=011, funct7=1001001 (bit[25]=1)
+        instrs += [
+            Instr('p.mac',           Format_RRRR, '1001000 ----- ----- 011 ----- 0101011', L='cv.mac'),
+            Instr('p.msu',           Format_RRRR, '1001001 ----- ----- 011 ----- 0101011', L='cv.msu'),
+        ]
+
+        super().__init__(name='pulpv2', instrs=instrs)

--- a/models/cpu/iss/src/core.cpp
+++ b/models/cpu/iss/src/core.cpp
@@ -56,6 +56,11 @@ void Core::build()
     this->iss.csr.mstatus.reset_val |= 2ULL << 34;
 #endif
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Default: no-op. Subclasses can override to apply a core-specific mask.
+    this->mstatus_write_mask_fixup();
+
+#endif
 #if ISS_REG_WIDTH == 64
     this->sstatus_write_mask = this->mstatus_write_mask & 0x80000003000DE762;
 #else
@@ -96,20 +101,39 @@ void Core::reset(bool active)
 }
 
 
-iss_reg_t Core::mret_handle()
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+void Core::mret_mode_restore()
 {
-    this->iss.exec.switch_to_full_mode();
-
     this->mode_set(this->iss.csr.mstatus.mpp);
 #ifdef CONFIG_GVSOC_ISS_USER_MODE
     this->iss.csr.mstatus.mpp = PRIV_U;
 #else
     this->iss.csr.mstatus.mpp = PRIV_M;
 #endif
+}
+
+#endif
+iss_reg_t Core::mret_handle()
+{
+    this->iss.exec.switch_to_full_mode();
+
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Privilege-mode restore on MRET (default: from mstatus.mpp).
+    this->mret_mode_restore();
+#else
+    this->mode_set(this->iss.csr.mstatus.mpp);
+#ifdef CONFIG_GVSOC_ISS_USER_MODE
+    this->iss.csr.mstatus.mpp = PRIV_U;
+#else
+    this->iss.csr.mstatus.mpp = PRIV_M;
+#endif
+#endif
     this->iss.irq.irq_enable.set(this->iss.csr.mstatus.mpie);
     this->iss.csr.mstatus.mie = this->iss.csr.mstatus.mpie;
     this->iss.csr.mstatus.mpie = 1;
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     this->iss.csr.mcause.value = 0;
+#endif
 
     return this->iss.csr.mepc.value;
 }
@@ -129,7 +153,9 @@ iss_reg_t Core::sret_handle()
     this->iss.irq.irq_enable.set(this->iss.csr.mstatus.spie);
     this->iss.csr.mstatus.sie = this->iss.csr.mstatus.spie;
     this->iss.csr.mstatus.spie = 1;
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     this->iss.csr.scause.value = 0;
+#endif
 
     return this->iss.csr.sepc.value;
 }
@@ -167,6 +193,9 @@ bool Core::mstatus_update(bool is_write, iss_reg_t &value)
     else
     {
         value = this->iss.csr.mstatus.value;
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+        this->iss.csr.mstatus_read_fixup(value);
+#endif
     }
 
     return false;

--- a/models/cpu/iss/src/csr.cpp
+++ b/models/cpu/iss/src/csr.cpp
@@ -71,6 +71,20 @@ Csr::Csr(Iss &iss)
     this->declare_csr(&this->tdata2,   "tdata2",       0x7A2);
     this->declare_csr(&this->tdata3,   "tdata3",       0x7A3);
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Optional extension CSRs: without this config they remain unregistered
+    // and access falls through to the unsupported-CSR path (upstream behavior).
+    this->declare_csr(&this->tinfo,    "tinfo",        0x7A4);
+    this->declare_csr(&this->mcontext, "mcontext",     0x7A8);
+    this->declare_csr(&this->scontext, "scontext",     0x7AA);
+
+    this->declare_csr(&this->minstret,   "minstret",    0xB02);
+#if ISS_REG_WIDTH == 32
+    this->declare_csr(&this->mcycleh,   "mcycleh",    0xB80);
+    this->declare_csr(&this->minstreth,  "minstreth",   0xB82);
+#endif
+
+#endif /* CONFIG_GVSOC_ISS_CV32E40P */
     // Machine Non-Maskable Interrupt Handling
     this->declare_csr(&this->mnscratch,   "mnscratch",    0x740);
     this->declare_csr(&this->mnepc,       "mnepc",        0x741);
@@ -96,6 +110,10 @@ Csr::Csr(Iss &iss)
     // Machine information registers
     this->declare_csr(&this->mvendorid,  "mvendorid",  0xF11);
     this->declare_csr(&this->marchid,    "marchid",    0xF12);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    this->declare_csr(&this->mimpid,     "mimpid",     0xF13);
+    this->declare_csr(&this->mhartid,    "mhartid",    0xF14);
+#endif
 
     this->declare_csr(&this->vstart, "vstart", 0x008, 0);
     this->declare_csr(&this->vxstat, "vxstat", 0x009);
@@ -210,7 +228,11 @@ void Csr::build()
 
     this->iss.top.new_master_port("time", &this->time_itf, (vp::Block *)this);
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    this->mhartid.value = (this->iss.top.get_js_config()->get_child_int("cluster_id") << 5) | this->iss.top.get_js_config()->get_child_int("core_id");
+#else
     this->mhartid = (this->iss.top.get_js_config()->get_child_int("cluster_id") << 5) | this->iss.top.get_js_config()->get_child_int("core_id");
+#endif
 
     this->tselect.register_callback(std::bind(&Csr::tselect_access, this, std::placeholders::_1, std::placeholders::_2));
 
@@ -224,7 +246,11 @@ bool Csr::tselect_access(bool is_write, iss_reg_t &value)
 {
     if (!is_write)
     {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+        value = this->tselect_default_read;
+#else
         value = -1;
+#endif
     }
     return false;
 }
@@ -237,6 +263,13 @@ bool Csr::time_access(bool is_write, iss_reg_t &value)
     return false;
 }
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+bool Csr::mstatus_access(bool is_write, iss_reg_t &value)
+{
+    return true;
+}
+
+#endif
 bool Csr::mcycle_access(bool is_write, iss_reg_t &value)
 {
     if (!is_write)
@@ -351,36 +384,78 @@ static bool uip_write(Iss *iss, unsigned int value)
 
 static bool fflags_read(Iss *iss, iss_reg_t *value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    if (iss->csr.fp_access_illegal())
+    {
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+#endif
     *value = iss->csr.fcsr.fflags;
     return false;
 }
 
 static bool fflags_write(Iss *iss, unsigned int value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    if (iss->csr.fp_access_illegal())
+    {
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+#endif
     iss->csr.fcsr.fflags = value;
     return false;
 }
 
 static bool frm_read(Iss *iss, iss_reg_t *value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    if (iss->csr.fp_access_illegal())
+    {
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+#endif
     *value = iss->csr.fcsr.frm;
     return false;
 }
 
 static bool frm_write(Iss *iss, unsigned int value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    if (iss->csr.fp_access_illegal())
+    {
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+#endif
     iss->csr.fcsr.frm = value;
     return false;
 }
 
 static bool fcsr_read(Iss *iss, iss_reg_t *value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    if (iss->csr.fp_access_illegal())
+    {
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+#endif
     *value = iss->csr.fcsr.raw;
     return false;
 }
 
 static bool fcsr_write(Iss *iss, unsigned int value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    if (iss->csr.fp_access_illegal())
+    {
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+#endif
     iss->csr.fcsr.raw = value & 0xff;
     return false;
 }
@@ -437,13 +512,21 @@ static bool scounteren_write(Iss *iss, unsigned int value)
 
 static bool mimpid_read(Iss *iss, iss_reg_t *value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    *value = iss->csr.mimpid.value;
+#else
     *value = 0;
+#endif
     return false;
 }
 
 static bool mhartid_read(Iss *iss, iss_reg_t *value)
 {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    *value = iss->csr.mhartid.value;
+#else
     *value = iss->csr.mhartid;
+#endif
     return false;
 }
 
@@ -891,6 +974,16 @@ bool iss_csr_read(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t *value)
   }
 #endif
 
+#if defined(CONFIG_GVSOC_ISS_CV32E40P) && (defined(CONFIG_GVSOC_ISS_RI5KY) || defined(CONFIG_GVSOC_ISS_HWLOOP))
+    // HWLOOP CSR mapping (matches hwloop_read gate above).
+    {
+        int hwloop_idx = iss->csr.hwloop_csr_index(reg);
+        if (hwloop_idx >= 0)
+        {
+            return hwloop_read(iss, hwloop_idx, value);
+        }
+    }
+#endif
     // New generic way of handling CSR access, all CSR should be accessed there
     if (!iss->csr.access(false, reg, *value))
     {
@@ -901,6 +994,7 @@ bool iss_csr_read(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t *value)
     switch (reg)
     {
 
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     // User trap setup
     case 0x000:
         status = ustatus_read(iss, value);
@@ -928,6 +1022,7 @@ bool iss_csr_read(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t *value)
     case 0x044:
         status = uip_read(iss, value);
         break;
+#endif
 
     // User floating-point CSRs
     case 0x001:
@@ -1096,9 +1191,11 @@ bool iss_csr_read(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t *value)
         status = mhartid_read(iss, value);
         break;
 
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     case 0x306:
         status = mcounteren_read(iss, value);
         break;
+#endif
 
 
     // Machine timers and counters
@@ -1260,9 +1357,22 @@ bool iss_csr_read(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t *value)
 
         if (status)
         {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+            // Config field decides exception vs warning per core.
+            if (iss->csr.raise_on_unsupported_csr_flag)
+            {
+                iss->csr.trace.msg(vp::Trace::LEVEL_DEBUG, "Unsupported CSR read (id: 0x%x) -> illegal instruction\n", reg);
+                iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+            }
+            else
+            {
+                iss->csr.trace.force_warning("Accessing unsupported CSR (id: 0x%x, name: %s)\n", reg, iss_csr_name(iss, reg));
+            }
+#else
             iss->csr.trace.force_warning("Accessing unsupported CSR (id: 0x%x, name: %s)\n", reg, iss_csr_name(iss, reg));
 #if 0
       triggerException_cause(iss, iss->currentPc, EXCEPTION_ILLEGAL_INSTR, ECAUSE_ILL_INSTR);
+#endif
 #endif
             return true;
         }
@@ -1278,6 +1388,16 @@ bool iss_csr_write(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t value)
     iss->csr.trace.msg("Writing CSR (reg: 0x%x, name: %s, value: 0x%x)\n",
         reg, iss_csr_name(iss, reg), value);
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // HWLOOP CSRs are not writable via csrrw on CV32E40P: raise illegal.
+    if (iss->csr.hwloop_csr_index(reg) >= 0)
+    {
+        iss->csr.trace.msg("Illegal CSR write to hwloop register (id: 0x%x)\n", reg);
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+        return true;
+    }
+
+#endif
     // If there is any write to a CSR, switch to full check instruction handler
     // in case something special happened (like HW counting become active)
     iss->exec.switch_to_full_mode();
@@ -1301,6 +1421,7 @@ bool iss_csr_write(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t value)
     switch (reg)
     {
 
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     // User trap setup
     case 0x000:
         return ustatus_write(iss, value);
@@ -1320,6 +1441,7 @@ bool iss_csr_write(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t value)
         return ubadaddr_write(iss, value);
     case 0x044:
         return uip_write(iss, value);
+#endif
 
     // User floating-point CSRs
     case 0x001:
@@ -1389,9 +1511,22 @@ bool iss_csr_write(Iss *iss, iss_insn_t *insn, iss_reg_t reg, iss_reg_t value)
         return hwloop_write(iss, reg - CSR_HWLOOP0_START, value);
 #endif
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Config field decides exception vs warning per core.
+    if (iss->csr.raise_on_unsupported_csr_flag)
+    {
+        iss->csr.trace.msg(vp::Trace::LEVEL_DEBUG, "Unsupported CSR write (id: 0x%x) -> illegal instruction\n", reg);
+        iss->exception.raise(iss->exec.current_insn, ISS_EXCEPT_ILLEGAL);
+    }
+    else
+    {
+        iss->csr.trace.force_warning("Accessing unsupported CSR (id: 0x%x, name: %s)\n", reg, iss_csr_name(iss, reg));
+    }
+#else
     iss->csr.trace.force_warning("Accessing unsupported CSR (id: 0x%x, name: %s)\n", reg, iss_csr_name(iss, reg));
 #if 0
   triggerException_cause(iss, iss->currentPc, EXCEPTION_ILLEGAL_INSTR, ECAUSE_ILL_INSTR);
+#endif
 #endif
 
     return true;
@@ -1709,6 +1844,13 @@ const char *iss_csr_name(Iss *iss, iss_reg_t reg)
     }
 #endif
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Core-specific CSR name lookup (default: fall through to "unknown").
+    if (const char *core_name = iss->csr.custom_csr_name(reg))
+    {
+        return core_name;
+    }
+#endif
     return "unknown";
 }
 

--- a/models/cpu/iss/src/cv32e40p/core_cv32e40p.cpp
+++ b/models/cpu/iss/src/cv32e40p/core_cv32e40p.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+
+#include <vp/vp.hpp>
+#include <cpu/iss/include/iss.hpp>
+
+// CV32E40P is M-mode only
+void Cv32e40pCore::mret_mode_restore()
+{
+    this->mode_set(PRIV_M);
+    this->iss.csr.mstatus.mpp = PRIV_M;
+}
+
+// only MIE(3) + MPIE(7) writable; MPP forced to M by hardware.
+// With FPU: add FS(14:13).
+void Cv32e40pCore::mstatus_write_mask_fixup()
+{
+    bool fpu_in_isa = this->iss.top.get_js_config()->get_child_bool("fpu_in_isa");
+    this->mstatus_write_mask = fpu_in_isa ? (iss_reg_t)0x6088 : (iss_reg_t)0x0088;
+}
+
+#endif /* CONFIG_GVSOC_ISS_CV32E40P */

--- a/models/cpu/iss/src/cv32e40p/csr_cv32e40p.cpp
+++ b/models/cpu/iss/src/cv32e40p/csr_cv32e40p.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CV32E40P-specific CSR subclass implementation.
+ *
+ *
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+
+#include "cpu/iss/include/iss.hpp"
+
+// Helper: read config int with fallback default.
+// Uses get() to distinguish "key missing" from "key=0".
+static inline int cfg_int_or(js::Config *cfg, const char *key, int dflt)
+{
+    js::Config *child = cfg->get(key);
+    return child ? child->get_int() : dflt;
+}
+
+Cv32e40pCsr::Cv32e40pCsr(Iss &iss)
+    : Csr(iss)
+{
+    // All CSR customization moved to build() — constructor runs too early
+    // during Iss member initialization (iss.top not yet set).
+}
+
+void Cv32e40pCsr::build()
+{
+    Csr::build();  // Base class CSR setup (regs map, trace, etc.)
+    this->build_cv32e40p();  // CV32E40P-specific customization
+}
+
+void Cv32e40pCsr::build_cv32e40p()
+{
+    /* reset() runs AFTER build() in GVSOC — reset_val must be correct */
+
+    // Cache FPU/ZFINX config for hot-path use
+    this->m_fpu_in_isa = this->iss.top.get_js_config()->get_child_bool("fpu_in_isa");
+    this->m_zfinx = this->iss.top.get_js_config()->get_child_bool("zfinx");
+
+    // CV32E40P mstatus access callback — forces MPP=M on reads, lets writes
+    // proceed via Cv32e40pCsr::mstatus_access() override.
+    this->mstatus.register_callback(std::bind(&Cv32e40pCsr::mstatus_access, this, std::placeholders::_1, std::placeholders::_2));
+
+    // CV32E40P is M-mode only: remove CSRs that don't exist
+    uint32_t nonexistent[] = {
+        0x100, 0x104, 0x105, 0x106,           // sstatus, sie, stvec, scounteren
+        0x140, 0x141, 0x142, 0x143, 0x144,     // sscratch, sepc, scause, stval, sip
+        0x302, 0x303,                           // medeleg, mideleg (no delegation)
+        0x306,                                  // mcounteren (no U-mode)
+        0x740, 0x741, 0x742, 0x744,             // NMI: mnscratch, mnepc, mncause, mnstatus
+        0x008, 0x009, 0x00A, 0x00F,             // Vector: vstart, vxstat, vxrm, vcsr
+        0xC20, 0xC21, 0xC22,                    // Vector: vl, vtype, vlenb
+    };
+    for (uint32_t addr : nonexistent)
+    {
+        this->undeclare_csr(addr);
+    }
+
+    // mhpmevent CSRs — base Csr skips these for CV32E40P, declare here in build_cv32e40p()
+    for (int i = 0; i < 29; i++)
+    {
+        this->declare_csr(&this->mhpmevent[i],
+            "mhpmevent" + std::to_string(i + 3), 0x323 + i);
+    }
+
+    // tinfo register — CV32E40P trigger info (read-only, value=0x4)
+    // base Csr now declares tinfo unconditionally (no undeclare+redeclare needed).
+    // reset_val and write_mask set below in this method.
+
+    auto *cfg = this->iss.top.get_js_config();
+
+    // PULP custom CSRs (0xCD0-0xCD2)
+    // These exist when COREV_PULP=1 (all PULP configs). Read-only via CSR instructions.
+    bool pulpv2 = cfg->get_child_bool("pulpv2");
+    if (pulpv2)
+    {
+        // PULP custom CSRs — reset_val MUST be passed to declare_csr()
+        // because Csr::reset() runs AFTER build() and overwrites .value with
+        // reset_val (default 0). Values set only via .value are clobbered.
+
+        // 0xCD0 UHARTID — duplicate of mhartid, user-mode readable
+        iss_reg_t uhartid_val = cfg_int_or(cfg, "mhartid_value", 0);
+        this->declare_csr(&this->uhartid, "uhartid", 0xCD0, uhartid_val);
+        this->uhartid.set_write_mask(0);  // read-only
+
+        // 0xCD1 PRIVLV — current privilege level (M-mode only → always 3)
+        this->declare_csr(&this->privlv, "privlv", 0xCD1, 3);
+        this->privlv.set_write_mask(0);  // read-only
+
+        // 0xCD2 ZFINX — returns 1 when FPU=1 && ZFINX=1, else 0
+        iss_reg_t zfinx_val = (this->m_zfinx) ? 1 : 0;
+        this->declare_csr(&this->zfinx_csr, "zfinx", 0xCD2, zfinx_val);
+        this->zfinx_csr.set_write_mask(0);  // read-only
+    }
+
+    // Read-only info registers
+    this->mvendorid.write_illegal = true;
+    this->mimpid.write_illegal = true;
+    this->marchid.write_illegal = true;
+    this->mhartid.write_illegal = true;
+
+    // ----------------------------------------------------------------
+    // CSR write masks — values from CV32E40P RTL
+    // Config Python values are used if present; fallback to RTL-derived
+    // constants if config key returns 0 (missing).
+    // ----------------------------------------------------------------
+
+    // mstatus effective write mask.
+    // CV32E40P forces MPP=M, MPRV=0, UIE=0, UPIE=0.
+    // Only MIE(3) + MPIE(7) are truly writable. With FPU: add FS(14:13).
+    // Reset is ALWAYS 0x1800 (FS=Off)
+    // even when FPU=1. FS transitions to Dirty
+    // only when FPU registers are written, not at reset.
+    iss_reg_t mstatus_wmask_dflt = this->m_fpu_in_isa ? 0x6088 : 0x0088;
+    iss_reg_t mstatus_reset = 0x00001800;  // MPP=M, FS=Off for ALL configs
+    this->mstatus.set_write_mask(cfg_int_or(cfg, "mstatus_write_mask", (int)mstatus_wmask_dflt));
+    this->mstatus.reset_val = mstatus_reset;
+    this->mstatus.value     = mstatus_reset;
+
+    // mie — only IRQ_MASK bits writable
+    this->mie.set_write_mask(cfg_int_or(cfg, "mie_write_mask", 0xFFFF0888));
+
+    // mip — read-only in M-mode
+    this->mip.set_write_mask(0);
+
+    // mtvec — bits[7:1] hardwired to 0
+    this->mtvec.set_write_mask(cfg_int_or(cfg, "mtvec_write_mask", 0xFFFFFF01));
+    this->mtvec.reset_val = cfg_int_or(cfg, "mtvec_reset", 0x1);
+    this->mtvec.value     = this->mtvec.reset_val;  // build() runs AFTER reset()
+
+    // mtval — CV32E40P hardwires mtval to 0 (not writable)
+    this->mtval.set_write_mask(cfg_int_or(cfg, "mtval_write_mask", 0x00000000));
+
+    // mcause — bit[31] (interrupt) + bits[4:0] (exception code)
+    this->mcause.set_write_mask(cfg_int_or(cfg, "mcause_mask", 0x8000001F));
+
+    // ----------------------------------------------------------------
+    // Trigger module CSRs
+    // ----------------------------------------------------------------
+    // tselect — CV32E40P has exactly 1 trigger, tselect hardwired to 0
+    this->tselect.reset_val = 0;
+    this->tselect.value     = 0;
+    this->tselect.set_write_mask(0);  // read-only: writes ignored, always reads 0
+    // tselect reads always return reset_val (0).
+    this->tselect_default_read = this->tselect.reset_val;
+
+    // tdata1 — type=2 (mcontrol), dmode=1, action=1, match=0, m=1
+    this->tdata1.reset_val = cfg_int_or(cfg, "tdata1_reset", 0x28001040);
+    this->tdata1.value     = this->tdata1.reset_val;
+    // tdata1 is writable ONLY from Debug Mode 
+    // In M-mode, all writes are silently ignored. 
+    // Since GVSOC model doesn't implement Debug Mode, mask=0.
+    this->tdata1.set_write_mask(cfg_int_or(cfg, "tdata1_write_mask", 0x00000000));
+
+    // tdata2 writable ONLY from Debug Mode (cv32e40p_cs_registers.sv:1263)
+    this->tdata2.set_write_mask(cfg_int_or(cfg, "tdata2_write_mask", 0x00000000));
+    this->tdata3.set_write_mask(cfg_int_or(cfg, "tdata3_write_mask", 0x00000000));
+
+    // mcontext/scontext — writable only from Debug Mode
+    this->mcontext.set_write_mask(cfg_int_or(cfg, "mcontext_write_mask", 0x00000000));
+    this->scontext.set_write_mask(cfg_int_or(cfg, "scontext_write_mask", 0x00000000));
+
+    // tinfo — read-only, bit[2]=1 (type 2 = mcontrol supported)
+    this->tinfo.reset_val = cfg_int_or(cfg, "tinfo_reset", 0x4);
+    this->tinfo.value     = this->tinfo.reset_val;
+    this->tinfo.set_write_mask(0);  // read-only
+
+    // ----------------------------------------------------------------
+    // Read-only info registers — initialization
+    // ----------------------------------------------------------------
+    // mvendorid — OpenHW JEDEC bank 13, RISC-V compliant
+    this->mvendorid.reset_val = cfg_int_or(cfg, "mvendorid_value", 0x00000602);
+    this->mvendorid.value     = this->mvendorid.reset_val;
+
+    // marchid — CV32E40P architecture ID
+    this->marchid.reset_val = cfg_int_or(cfg, "marchid_value", 0x00000004);
+    this->marchid.value     = this->marchid.reset_val;
+
+    // mhartid — hart ID (default 0, parameterizable per config)
+    this->mhartid.reset_val = cfg_int_or(cfg, "mhartid_value", 0x00000000);
+    this->mhartid.value     = this->mhartid.reset_val;
+
+    // mimpid from JSON config (RTL: FPU||COREV_PULP||COREV_CLUSTER ? 1 : 0)
+    this->mimpid.value = (iss_reg_t)cfg_int_or(cfg, "mimpid", 0);
+    this->mimpid.reset_val = this->mimpid.value;
+
+    // ----------------------------------------------------------------
+    // Counter CSRs
+    // ----------------------------------------------------------------
+
+    // mcountinhibit — RTL resets to write_mask value (all implemented bits set).
+    // With N=1 HPM counter: mask=0x0d (CY,IR,HPM3). With N=29: mask=0xfffffffd.
+    iss_reg_t mcountinhibit_mask = (iss_reg_t)cfg_int_or(cfg, "mcountinhibit_mask", 0x0d);
+    this->mcountinhibit.set_write_mask(mcountinhibit_mask);
+    this->mcountinhibit.reset_val = mcountinhibit_mask;
+    this->mcountinhibit.value     = mcountinhibit_mask;
+
+    // HPM counters: only first num_mhpmcounters are implemented
+    int num_hpm = cfg_int_or(cfg, "num_mhpmcounters", 1);
+    for (int i = 0; i < 29; i++)
+    {
+        if (i < num_hpm)
+        {
+            this->mhpmcounter[i].set_write_mask((iss_reg_t)-1);
+#if ISS_REG_WIDTH == 32
+            this->mhpmcounterh[i].set_write_mask((iss_reg_t)-1);
+#endif
+        }
+        else
+        {
+            // CV32E40P: unimplemented counters are WARL (writes ignored, no exception)
+            this->mhpmcounter[i].set_write_mask(0);
+#if ISS_REG_WIDTH == 32
+            this->mhpmcounterh[i].set_write_mask(0);
+#endif
+        }
+    }
+
+    // HPM event selectors: only mhpmevent3 has bits[15:0]
+    int num_hpm_events = cfg_int_or(cfg, "num_hpm_events", 16);
+    iss_reg_t evt_mask = (num_hpm_events > 0) ?
+        ((1U << num_hpm_events) - 1) : 0;
+    for (int i = 0; i < 29; i++)
+    {
+        this->mhpmevent[i].set_write_mask((i < num_hpm) ? evt_mask : 0);
+    }
+
+    // CV32E40P raises illegal-instruction on access to undeclared CSRs
+    // (RISC-V privileged spec strict mode); generic GVSOC just warns.
+    this->raise_on_unsupported_csr_flag = true;
+    // CV32E40P bootaddr does NOT write mtvec — it is set by Csr::build()
+    // (reset_val=0x1, vectored mode).
+    this->bootaddr_writes_mtvec_flag = false;
+
+    // dcsr — build() runs after reset(), so apply dcsr M-mode here too
+    this->dcsr = (4 << 28) | 0x3;
+}
+
+void Cv32e40pCsr::reset(bool active)
+{
+    Csr::reset(active);
+
+    // dcsr reset — xdebugver=4 in [31:28], prv=M-mode in [1:0]
+    // Base Csr::reset() sets dcsr = 4 << 28 (prv=0). CV32E40P is M-mode only.
+    this->dcsr = (4 << 28) | 0x3;
+
+    this->mcycle_offset = 0;
+
+    // Re-apply config-driven values after Csr::reset() which may clobber them
+    // with base-class defaults (e.g. marchid=0x14 from GVSOC base instead of
+    // 0x04 from CV32E40P RTL). Uses reset_val set by build_cv32e40p().
+    if (active)
+    {
+        this->mvendorid.value = this->mvendorid.reset_val;
+        this->marchid.value   = this->marchid.reset_val;
+        this->mimpid.value    = this->mimpid.reset_val;
+
+        // mstatus — Core::build() contaminates reset_val with FS=Dirty.
+        // CV32E40P: reset is ALWAYS 0x1800 (FS=Off, MPP=M) for ALL configs
+        // including FPU (RTL: mstatus_fs_q <= FS_OFF at reset).
+        iss_reg_t mstatus_rst = 0x00001800;
+        this->mstatus.reset_val = mstatus_rst;
+        this->mstatus.value     = mstatus_rst;
+
+        // tdata1 — re-apply value from build_cv32e40p() after Csr::reset()
+        // may have used a contaminated reset_val.  build_cv32e40p() reads
+        // tdata1_reset from JSON config (default 0x28001040: m=1, u=0).
+        this->tdata1.value = this->tdata1.reset_val;
+    }
+}
+
+bool Cv32e40pCsr::mstatus_access(bool is_write, iss_reg_t &value)
+{
+    // Return true → let CsrAbtractReg::access() handle the write_mask.
+    // For reads, force MPP=M so the value read is correct.
+    if (!is_write)
+    {
+        this->mstatus.mpp = PRIV_M;
+        value = this->mstatus.value;
+        return false;
+    }
+    return true;
+}
+
+bool Cv32e40pCsr::fp_access_illegal()
+{
+    // CV32E40P RTL (cv32e40p_cs_registers.sv): FP CSR (fflags/frm/fcsr) access
+    // raises illegal-instruction when mstatus[FS] == 00 (FS_OFF).
+    return ((this->mstatus.value >> 13) & 3) == 0;
+}
+
+int Cv32e40pCsr::hwloop_csr_index(iss_reg_t reg)
+{
+    // CoreV2 HWLOOP CSR addresses (gap at 0xCC3):
+    //   0xCC0..0xCC2 → loop 0 (start/end/count)  → indices 0..2
+    //   0xCC4..0xCC6 → loop 1 (start/end/count)  → indices 4..6
+    // Internal hwloop_regs[] uses stride 4 (per loop slot), matching CoreV2.
+    if ((reg >= 0xCC0 && reg <= 0xCC2) || (reg >= 0xCC4 && reg <= 0xCC6))
+    {
+        return reg - 0xCC0;
+    }
+    return -1;
+}
+
+const char *Cv32e40pCsr::custom_csr_name(iss_reg_t reg)
+{
+    switch (reg)
+    {
+        case 0xCC0: return "lpstart0";
+        case 0xCC1: return "lpend0";
+        case 0xCC2: return "lpcount0";
+        case 0xCC4: return "lpstart1";
+        case 0xCC5: return "lpend1";
+        case 0xCC6: return "lpcount1";
+        default:    return nullptr;  // fall through to base/generic
+    }
+}
+
+bool Cv32e40pCsr::mcycle_access(bool is_write, iss_reg_t &value)
+{
+    if (is_write)
+    {
+        this->mcycle.value = value;
+        this->mcycle_offset = (int64_t)value
+            - (int64_t)this->iss.top.clock.get_cycles();
+    }
+    else
+    {
+        if (this->mcountinhibit.value & 0x1)
+        {
+            value = this->mcycle.value;
+        }
+        else
+        {
+            value = (iss_reg_t)((int64_t)this->iss.top.clock.get_cycles()
+                + this->mcycle_offset);
+        }
+    }
+    return false;
+}
+
+void Cv32e40pCsr::mstatus_read_fixup(iss_reg_t &value)
+{
+    /* CV32E40P: set mstatus.SD (bit 31) when FS[14:13]==3 or XS[16:15]==3.
+     * This matches read-back behavior for mstatus. */
+    if (this->m_fpu_in_isa && (((value >> 13) & 3) == 3 || ((value >> 15) & 3) == 3))
+    {
+        value |= (1ULL << 31);
+    }
+}
+
+// EBREAK in M-mode enters debug when dcsr.ebreakm=1.
+bool Cv32e40pCsr::ebreak_m_mode_enters_debug()
+{
+    return (this->dcsr >> 15) & 1;
+}
+
+#endif /* CONFIG_GVSOC_ISS_CV32E40P */

--- a/models/cpu/iss/src/cv32e40p/irq_cv32e40p.cpp
+++ b/models/cpu/iss/src/cv32e40p/irq_cv32e40p.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 GreenWaves Technologies, SAS, ETH Zurich and
+ *                    University of Bologna
+ * Copyright (C) 2026 Fondazione Chips-it
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Authors: Marco Paci, Fondazione Chips-it (marco.paci@chips.it)
+ */
+
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+
+#include <vp/vp.hpp>
+#include <cpu/iss/include/iss.hpp>
+
+void Cv32e40pIrq::register_csr_callbacks()
+{
+    this->iss.csr.mip.register_callback(std::bind(&Cv32e40pIrq::mip_access, this, std::placeholders::_1, std::placeholders::_2));
+    this->iss.csr.mie.register_callback(std::bind(&Cv32e40pIrq::mie_access, this, std::placeholders::_1, std::placeholders::_2));
+    this->iss.csr.mtvec.register_callback(std::bind(&Cv32e40pIrq::mtvec_access, this, std::placeholders::_1, std::placeholders::_2));
+}
+
+bool Cv32e40pIrq::mip_access(bool is_write, iss_reg_t &value)
+{
+    if (is_write)
+    {
+        iss_reg_t mask = this->iss.csr.mip.write_mask;
+        this->iss.csr.mip.value = (this->iss.csr.mip.value & ~mask) | (value & mask);
+    }
+    else
+    {
+        value = this->iss.csr.mip.value;
+    }
+    this->check_interrupts();
+    return false;
+}
+
+bool Cv32e40pIrq::mie_access(bool is_write, iss_reg_t &value)
+{
+    if (is_write)
+    {
+        iss_reg_t mask = this->iss.csr.mie.write_mask;
+        this->iss.csr.mie.value = (this->iss.csr.mie.value & ~mask) | (value & mask);
+    }
+    else
+    {
+        value = this->iss.csr.mie.value;
+    }
+    this->check_interrupts();
+    return false;
+}
+
+bool Cv32e40pIrq::mtvec_access(bool is_write, iss_reg_t &value)
+{
+    if (is_write)
+    {
+        this->mtvec_set(value);
+        iss_reg_t mask = this->iss.csr.mtvec.write_mask;
+        this->iss.csr.mtvec.value = (this->iss.csr.mtvec.value & ~mask) | (value & mask);
+        return false;
+    }
+    else
+    {
+        value = this->iss.csr.mtvec.value;
+        return true;
+    }
+}
+
+void Cv32e40pIrq::elw_irq_unstall()
+{
+    this->trace.msg("Interrupting pending elw\n");
+    this->iss.exec.current_insn = this->iss.exec.elw_insn;
+    this->iss.exec.elw_interrupted = 1;
+    this->iss.exec.busy_enter();
+}
+
+
+#endif /* CONFIG_GVSOC_ISS_CV32E40P */

--- a/models/cpu/iss/src/exception.cpp
+++ b/models/cpu/iss/src/exception.cpp
@@ -80,12 +80,20 @@ void Exception::raise(iss_reg_t pc, int id)
 #ifdef CONFIG_GVSOC_ISS_RISCV_EXCEPTIONS
         if (next_mode == PRIV_M)
         {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+            pc = this->iss.csr.mtvec.value & this->trap_vector_align_mask;
+#else
             pc = this->iss.csr.mtvec.value;
+#endif
             this->iss.csr.mcause.value = id;
         }
         else
         {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+            pc = this->iss.csr.stvec.value & this->trap_vector_align_mask;
+#else
             pc = this->iss.csr.stvec.value;
+#endif
             this->iss.csr.scause.value = id;
         }
 #else

--- a/models/cpu/iss/src/exec/exec_inorder.cpp
+++ b/models/cpu/iss/src/exec/exec_inorder.cpp
@@ -168,6 +168,15 @@ void Exec::exec_instr(vp::Block *__this, vp::ClockEvent *event)
 
     if (iss->exec.handle_stall_cycles()) return;
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Combinatorial DECODE-stage IRQ check: redirect to mtvec before fetching
+    // the next instruction if an interrupt is pending.
+    if (!iss->exec.skip_irq_check && iss->irq.check())
+    {
+        return;
+    }
+
+#endif
     iss->exec.trace.msg(vp::Trace::LEVEL_TRACE, "Handling instruction with fast handler\n");
 
     iss_reg_t pc = iss->exec.current_insn;
@@ -325,7 +334,17 @@ void Exec::exec_instr_check_all(vp::Block *__this, vp::ClockEvent *event)
 
     if (!_this->skip_irq_check)
     {
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+        /* Combinatorial DECODE-stage IRQ check (mirrors RTL controller): on a
+         * pending interrupt, redirect to mtvec before fetching next insn so
+         * mepc captures the right PC. */
+        if (_this->iss.irq.check())
+        {
+            return;
+        }
+#else
         _this->iss.irq.check();
+#endif
     }
     else
     {
@@ -432,8 +451,18 @@ void Exec::fetchen_sync(vp::Block *__this, bool active)
 void Exec::bootaddr_apply(uint32_t value)
 {
     this->trace.msg("Setting boot address (value: 0x%x)\n", value);
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    // Config flag: CV32E40P keeps its own mtvec reset value instead of
+    // deriving mtvec from the boot address.
+    if (this->iss.csr.bootaddr_writes_mtvec_flag)
+    {
+        iss_reg_t bootaddr = this->bootaddr_reg.get() & ~((1 << 8) - 1);
+        this->iss.csr.mtvec.access(true, bootaddr);
+    }
+#else
     iss_reg_t bootaddr = this->bootaddr_reg.get() & ~((1 << 8) - 1);
     this->iss.csr.mtvec.access(true, bootaddr);
+#endif
 
 }
 

--- a/models/cpu/iss/src/irq/irq_riscv.cpp
+++ b/models/cpu/iss/src/irq/irq_riscv.cpp
@@ -33,12 +33,19 @@ void Irq::build()
     iss.top.traces.new_trace("irq", &this->trace, vp::DEBUG);
 
     this->iss.csr.mideleg.register_callback(std::bind(&Irq::mideleg_access, this, std::placeholders::_1, std::placeholders::_2));
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     this->iss.csr.mip.register_callback(std::bind(&Irq::mip_access, this, std::placeholders::_1, std::placeholders::_2));
     this->iss.csr.mie.register_callback(std::bind(&Irq::mie_access, this, std::placeholders::_1, std::placeholders::_2));
+#endif
     this->iss.csr.sip.register_callback(std::bind(&Irq::sip_access, this, std::placeholders::_1, std::placeholders::_2));
     this->iss.csr.sie.register_callback(std::bind(&Irq::sie_access, this, std::placeholders::_1, std::placeholders::_2));
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
     this->iss.csr.mtvec.register_callback(std::bind(&Irq::mtvec_access, this, std::placeholders::_1, std::placeholders::_2));
+#endif
     this->iss.csr.stvec.register_callback(std::bind(&Irq::stvec_access, this, std::placeholders::_1, std::placeholders::_2));
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    this->register_csr_callbacks();
+#endif
 
     this->msi_itf.set_sync_meth(&Irq::msi_sync);
     this->iss.top.new_slave_port("msi", &this->msi_itf, (vp::Block *)this);
@@ -60,6 +67,15 @@ void Irq::build()
     }
 }
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+void Irq::register_csr_callbacks()
+{
+    this->iss.csr.mip.register_callback(std::bind(&Irq::mip_access, this, std::placeholders::_1, std::placeholders::_2));
+    this->iss.csr.mie.register_callback(std::bind(&Irq::mie_access, this, std::placeholders::_1, std::placeholders::_2));
+    this->iss.csr.mtvec.register_callback(std::bind(&Irq::mtvec_access, this, std::placeholders::_1, std::placeholders::_2));
+}
+
+#endif
 void Irq::reset(bool active)
 {
     if (active)
@@ -71,8 +87,10 @@ void Irq::reset(bool active)
     }
     else
     {
+#ifndef CONFIG_GVSOC_ISS_CV32E40P
         this->mtvec_set(this->iss.exec.bootaddr_reg.get() & ~((1 << 8) - 1));
         this->stvec_set(this->iss.exec.bootaddr_reg.get() & ~((1 << 8) - 1));
+#endif
     }
 }
 
@@ -216,6 +234,13 @@ bool Irq::stvec_set(iss_addr_t base)
     return true;
 }
 
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+void Irq::elw_irq_unstall()
+{
+    // Base implementation: no-op. The CV32E40P subclass overrides this.
+}
+
+#endif
 void Irq::cache_flush()
 {
 }

--- a/models/cpu/iss/src/lsu.cpp
+++ b/models/cpu/iss/src/lsu.cpp
@@ -555,7 +555,11 @@ bool Lsu::atomic(iss_insn_t *insn, iss_addr_t addr, int size, int reg_in, int re
 //     uint8_t *check_second_data = (uint8_t *)this->iss.regfile.reg_ref(reg_out);
 //     req->set_second_memcheck_data(check_second_data);
 // #endif
+#ifdef CONFIG_GVSOC_ISS_CV32E40P
+    req->set_initiator(this->iss.csr.mhartid.value);
+#else
     req->set_initiator(this->iss.csr.mhartid);
+#endif
 
     this->log_addr.set_and_release(addr);
     this->log_size.set_and_release(size);


### PR DESCRIPTION
## Summary

Add CV32E40P (PULP RI5CY) core model to the GVSOC ISS, enabling cycle-accurate simulation and DPI co-simulation with the CV32E40P UVM testbench.

### What's included

- **Core model** (`models/cpu/iss/include/cores/cv32e40p/`): CSR subclassing, IRQ handling, exception model, privilege mode, register file — all behind `#ifdef CONFIG_GVSOC_ISS_CV32E40P` guards
- **CoreV2 ISA handlers** (`corev.hpp`): PULP custom instructions (hardware loops, post-increment load/store, SIMD, bit manipulation) unified for both ISS v1 and v2
- **CSR implementation** (`csr_cv32e40p.cpp`): Full CV32E40P CSR map with configurable write masks, reset values, and volatile flags driven by JSON config
- **IRQ controller** (`irq_cv32e40p.cpp`): PULP-style fast interrupt handling with 16 local interrupts
- **Exit device** (`cv32e40p_exit_device.cpp`): Memory-mapped exit device for standalone simulation
- **Build system**: CMakeLists.txt updates, ISA generator for CoreV2 encoding

### Base class extensions (non-breaking)

Small extensions to `csr.hpp`, `exception.hpp`, `irq_riscv.hpp`, `exec_inorder.cpp` to support core-specific subclassing. All changes are backward-compatible — existing cores (snitch, ri5ky, ara) are unaffected.

### Validation

- GVSOC standalone: 5 config variants tested (default, PULP, FPU, ZFINX, PULP+FPU+ZFINX)
- DPI co-simulation: 39/43 test×config pairs PASS against CV32E40P RTL (Questa 2025.3)
- Upstream build: `make build TARGETS=rv64` passes without regressions

### Related PRs

- gvsoc-pulp: CV32E40P platform definition and core config (to be linked)