### PR TITLE
Fixes for Snitch core and interleaver

### DIFF
--- a/models/cpu/iss/include/lsu_implem.hpp
+++ b/models/cpu/iss/include/lsu_implem.hpp
@@ -133,9 +133,6 @@ inline bool Lsu::load(iss_insn_t *insn, iss_addr_t addr, int size, int reg)
         if (err != vp::IO_REQ_INVALID)
         {
 #ifdef CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING
-#ifdef CONFIG_GVSOC_ISS_SCOREBOARD
-            this->iss.regfile.scoreboard_reg_invalidate(reg);
-#endif
             // We repeat the instruction only when no request was available.
             // If the request was allocated but denied, the core is stalled and unstalled
             // when the grant is received
@@ -143,6 +140,9 @@ inline bool Lsu::load(iss_insn_t *insn, iss_addr_t addr, int size, int reg)
             {
                 return true;
             }
+#ifdef CONFIG_GVSOC_ISS_SCOREBOARD
+            this->iss.regfile.scoreboard_reg_invalidate(reg);
+#endif
             this->stall_callback[req_id] = &Lsu::load_resume;
             this->stall_reg[req_id] = reg;
             this->stall_insn[req_id] = insn->addr;
@@ -259,9 +259,6 @@ inline bool Lsu::load_signed(iss_insn_t *insn, iss_addr_t addr, int size, int re
         if (err != vp::IO_REQ_INVALID)
         {
 #ifdef CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING
-#ifdef CONFIG_GVSOC_ISS_SCOREBOARD
-            this->iss.regfile.scoreboard_reg_invalidate(reg);
-#endif
             // We repeat the instruction only when no request was available.
             // If the request was allocated but denied, the core is stalled and unstalled
             // when the grant is received
@@ -269,6 +266,9 @@ inline bool Lsu::load_signed(iss_insn_t *insn, iss_addr_t addr, int size, int re
             {
                 return true;
             }
+#ifdef CONFIG_GVSOC_ISS_SCOREBOARD
+            this->iss.regfile.scoreboard_reg_invalidate(reg);
+#endif
             this->stall_callback[req_id] = &Lsu::load_signed_resume;
             this->stall_reg[req_id] = reg;
             this->stall_size[req_id] = size;
@@ -481,9 +481,6 @@ inline bool Lsu::load_float(iss_insn_t *insn, iss_addr_t addr, int size, int reg
         if (err != vp::IO_REQ_INVALID)
         {
 #ifdef CONFIG_GVSOC_ISS_LSU_NB_OUTSTANDING
-#ifdef CONFIG_GVSOC_ISS_SCOREBOARD
-            this->iss.regfile.scoreboard_reg_invalidate(reg);
-#endif
             // We repeat the instruction only when no request was available.
             // If the request was allocated but denied, the core is stalled and unstalled
             // when the grant is received
@@ -491,6 +488,9 @@ inline bool Lsu::load_float(iss_insn_t *insn, iss_addr_t addr, int size, int reg
             {
                 return true;
             }
+#ifdef CONFIG_GVSOC_ISS_SCOREBOARD
+            this->iss.regfile.scoreboard_reg_invalidate(reg);
+#endif
             this->stall_callback[req_id] = &Lsu::load_float_resume;
             this->stall_reg[req_id] = reg;
             this->stall_size[req_id] = size;

--- a/models/cpu/iss/src/snitch_fast/sequencer.cpp
+++ b/models/cpu/iss/src/snitch_fast/sequencer.cpp
@@ -69,6 +69,8 @@ void Sequencer::reset(bool active)
         this->frep_enabled = false;
         this->total_insn_count = 0;
         this->total_insn_read_count = 0;
+        this->insn_count = 0;
+        this->rpt_count = 0;
     }
 }
 

--- a/models/interco/interleaver_impl.cpp
+++ b/models/interco/interleaver_impl.cpp
@@ -138,7 +138,6 @@ vp::IoReqStatus interleaver::req(vp::Block *__this, vp::IoReq *req)
     }
     else if (_this->enable_shift)
     {
-      output_id = (offset >> (_this->interleaving_bits + _this->enable_shift)) & ((1 << _this->stage_bits) - 1);
       new_offset = ((offset >> _this->enable_shift) & (-1ULL << _this->interleaving_bits)) | (offset & ((1ULL << _this->interleaving_bits) - 1));
     }
     else

--- a/models/interco/interleaver_impl.cpp
+++ b/models/interco/interleaver_impl.cpp
@@ -152,7 +152,7 @@ vp::IoReqStatus interleaver::req(vp::Block *__this, vp::IoReq *req)
     req->set_addr(new_offset);
     req->set_size(loop_size);
     req->set_data(data);
-    req->set_latency(init_latency);
+    req->set_exact_latency(init_latency);
 
     vp::IoReqStatus err = _this->out[output_id]->req_forward(req);
     if (err != vp::IO_REQ_OK)


### PR DESCRIPTION
In terms of latency calculation in the interleaver, the set_latency fails to set the latency back to the original value if the current latency is larger, so I added a dedicated function that can override the value unconditionally. I am not sure if this is a good solution, let me know if you have any suggestions :)